### PR TITLE
Fix CSP

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -14,7 +14,7 @@
     "128": "assets/images/marina-logo-green-128.png"
   },
   "web_accessible_resources": [],
-  "content_security_policy": "script-src 'self' 'unsafe-eval'",
+  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "browser_action": {
     "default_icon": "assets/images/marina-logo-green-128.png",
     "default_popup": "popup.html"


### PR DESCRIPTION
Fix warnings on Firefox

```
Reading manifest: Error processing content_security_policy: Policy is missing a required 'object-src' directive
```
```
Reading manifest: Error processing content_security_policy: Value "script-src 'self' 'unsafe-eval'" must either: match the format "contentSecurityPolicy", or be an object value
```