### PR TITLE
Move Context creation to its own file

### DIFF
--- a/src/application/background_script.ts
+++ b/src/application/background_script.ts
@@ -1,8 +1,5 @@
-import React from 'react';
-import { appInitialState } from './store/reducers';
 import { browser } from 'webextension-polyfill-ts';
 import { INITIALIZE_WELCOME_ROUTE } from '../presentation/routes/constants';
-import { IAppState } from '../domain/common';
 import { BrowserStorageAppRepo } from '../infrastructure/app/browser/browser-storage-app-repository';
 import { BrowserStorageWalletRepo } from '../infrastructure/wallet/browser/browser-storage-wallet-repository';
 import { initPersistentStore } from '../infrastructure/init-persistent-store';
@@ -39,7 +36,3 @@ browser.runtime.onInstalled.addListener(({ reason, temporary }) => {
     //   break;
   }
 });
-
-// Create store
-type ctx = [IAppState, React.Dispatch<unknown>];
-export const AppContext = React.createContext<ctx>(appInitialState);

--- a/src/application/store/context.ts
+++ b/src/application/store/context.ts
@@ -1,0 +1,6 @@
+import React from 'react';
+import { IAppState } from '../../domain/common';
+import { appInitialState } from './reducers';
+
+type ctx = [IAppState, React.Dispatch<unknown>];
+export const AppContext = React.createContext<ctx>(appInitialState);

--- a/src/presentation/app.tsx
+++ b/src/presentation/app.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { HashRouter } from 'react-router-dom';
 import { appReducer, appInitialState } from '../application/store/reducers';
-import { AppContext } from '../application/background_script';
+import { AppContext } from '../application/store/context';
 import Routes from './routes';
 import useThunkReducer from '../application/store/reducers/use-thunk-reducer';
 import { BrowserStorageAppRepo } from '../infrastructure/app/browser/browser-storage-app-repository';

--- a/src/presentation/components/modal-menu.tsx
+++ b/src/presentation/components/modal-menu.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useRef } from 'react';
 import { useHistory } from 'react-router';
-import { AppContext } from '../../application/background_script';
+import { AppContext } from '../../application/store/context';
 import { logOut } from '../../application/store/actions';
 import useOnClickOutside from '../hooks/use-onclick-outside';
 import {

--- a/src/presentation/onboarding/seed-confirm/index.tsx
+++ b/src/presentation/onboarding/seed-confirm/index.tsx
@@ -4,7 +4,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { INITIALIZE_END_OF_FLOW_ROUTE } from '../../routes/constants';
 import Shell from '../../components/shell';
 import MnemonicDnd from '../../components/mnemonic-dnd';
-import { AppContext } from '../../../application/background_script';
+import { AppContext } from '../../../application/store/context';
 import { onboardingComplete, verifyWallet } from '../../../application/store/actions';
 
 interface LocationState {

--- a/src/presentation/onboarding/seed-reveal/index.tsx
+++ b/src/presentation/onboarding/seed-reveal/index.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import * as bip39 from 'bip39';
 import { useHistory, useLocation } from 'react-router-dom';
-import { AppContext } from '../../../application/background_script';
+import { AppContext } from '../../../application/store/context';
 import { createWallet, onboardingComplete } from '../../../application/store/actions';
 import Button from '../../components/button';
 import {

--- a/src/presentation/onboarding/wallet-create/index.tsx
+++ b/src/presentation/onboarding/wallet-create/index.tsx
@@ -5,7 +5,7 @@ import * as Yup from 'yup';
 import cx from 'classnames';
 import Button from '../../components/button';
 import Shell from '../../components/shell';
-import { AppContext } from '../../../application/background_script';
+import { AppContext } from '../../../application/store/context';
 import { INITIALIZE_SEED_PHRASE_ROUTE } from '../../routes/constants';
 import { DispatchOrThunk } from '../../../domain/common';
 

--- a/src/presentation/onboarding/wallet-restore/index.tsx
+++ b/src/presentation/onboarding/wallet-restore/index.tsx
@@ -3,7 +3,7 @@ import { useHistory, RouteComponentProps } from 'react-router-dom';
 import cx from 'classnames';
 import { withFormik, FormikProps } from 'formik';
 import * as Yup from 'yup';
-import { AppContext } from '../../../application/background_script';
+import { AppContext } from '../../../application/store/context';
 import { onboardingComplete, restoreWallet } from '../../../application/store/actions';
 import Button from '../../components/button';
 import Shell from '../../components/shell';

--- a/src/presentation/routes/guards.tsx
+++ b/src/presentation/routes/guards.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { Route, Redirect, RouteProps, RouteComponentProps } from 'react-router-dom';
-import { AppContext } from '../../application/background_script';
+import { AppContext } from '../../application/store/context';
 
 /**
  * A wrapper for <Route> that redirects to the login screen if you're not yet authenticated

--- a/src/presentation/settings/change-password.tsx
+++ b/src/presentation/settings/change-password.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { RouteComponentProps, useHistory } from 'react-router';
 import { FormikProps, withFormik } from 'formik';
 import * as Yup from 'yup';
-import { AppContext } from '../../application/background_script';
+import { AppContext } from '../../application/store/context';
 import ShellPopUp from '../components/shell-popup';
 import Button from '../components/button';
 import Input from '../components/input';

--- a/src/presentation/settings/explorer.tsx
+++ b/src/presentation/settings/explorer.tsx
@@ -5,7 +5,7 @@ import * as Yup from 'yup';
 import ShellPopUp from '../components/shell-popup';
 import Input from '../components/input';
 import { DispatchOrThunk } from '../../domain/common';
-import { AppContext } from '../../application/background_script';
+import { AppContext } from '../../application/store/context';
 import Button from '../components/button';
 
 interface SettingsExplorerFormValues {

--- a/src/presentation/settings/networks.tsx
+++ b/src/presentation/settings/networks.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { AppContext } from '../../application/background_script';
+import { AppContext } from '../../application/store/context';
 import { changeNetwork } from '../../application/store/actions';
 import { Network } from '../../domain/app/value-objects/network';
 import Select from '../components/select';

--- a/src/presentation/settings/show-mnemonic.tsx
+++ b/src/presentation/settings/show-mnemonic.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { AppContext } from '../../application/background_script';
+import { AppContext } from '../../application/store/context';
 import { decrypt } from '../../application/utils/crypto';
 import { Password } from '../../domain/wallet/value-objects';
 import ModalUnlock from '../components/modal-unlock';

--- a/src/presentation/wallet/log-in/index.tsx
+++ b/src/presentation/wallet/log-in/index.tsx
@@ -3,7 +3,7 @@ import { Link, RouteComponentProps, useHistory } from 'react-router-dom';
 import cx from 'classnames';
 import { FormikProps, withFormik } from 'formik';
 import * as Yup from 'yup';
-import { AppContext } from '../../../application/background_script';
+import { AppContext } from '../../../application/store/context';
 import { logIn } from '../../../application/store/actions';
 import { DEFAULT_ROUTE, RESTORE_VAULT_ROUTE } from '../../routes/constants';
 import Button from '../../components/button';

--- a/src/presentation/wallet/receive/index.tsx
+++ b/src/presentation/wallet/receive/index.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import QRCode from 'qrcode.react';
 import { DEFAULT_ROUTE } from '../../routes/constants';
-import { AppContext } from '../../../application/background_script';
+import { AppContext } from '../../../application/store/context';
 import { deriveNewAddress } from '../../../application/store/actions';
 import Button from '../../components/button';
 import ShellPopUp from '../../components/shell-popup';

--- a/src/presentation/wallet/send/address-amount.tsx
+++ b/src/presentation/wallet/send/address-amount.tsx
@@ -4,7 +4,7 @@ import cx from 'classnames';
 import { withFormik, FormikProps } from 'formik';
 import * as Yup from 'yup';
 import { DEFAULT_ROUTE, SEND_CHOOSE_FEE_ROUTE } from '../../routes/constants';
-import { AppContext } from '../../../application/background_script';
+import { AppContext } from '../../../application/store/context';
 import { DispatchOrThunk } from '../../../domain/common';
 import Balance from '../../components/balance';
 import Button from '../../components/button';


### PR DESCRIPTION
Refactoring: Context creation doesn't belong to background-script.ts. It has been done like this during the first draft, but was a mistake. This PR move Context creation to its own file 