### PR TITLE
open onboarding page if wallet not created

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -16,7 +16,6 @@
   "web_accessible_resources": [],
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "browser_action": {
-    "default_icon": "assets/images/marina-logo-green-128.png",
-    "default_popup": "popup.html"
+    "default_icon": "assets/images/marina-logo-green-128.png"
   }
 }


### PR DESCRIPTION
**This PR handles toolbar button behavior. If the user has already created/restored a wallet: the popup appears. Otherwise, the onboarding page is open in a new tab.**

- modify `background_script`: add a listener on `browser.browserAction.onclicked` event + create the `openInitializeWelcomeRoute`.
- modify `manifest.json`: remove the line setting `default_popup`. 
- This [check](https://github.com/vulpemventures/marina/blob/016ca481eeb67b9abd909ff139e619dd2c90ec36/src/application/background_script.ts#L47-L52) is here for performance: if the popup is already set: we admit that the user has already created his wallet.

it closes #32 

@tiero @altafan @Janaka-Steph please review