### PR TITLE
Recover UI after Confirmation screen closed + flush tx

### DIFF
--- a/src/application/store/actions/transaction.ts
+++ b/src/application/store/actions/transaction.ts
@@ -1,3 +1,4 @@
+import { browser } from 'webextension-polyfill-ts';
 import {
   PENDING_TX_SET_ASSET,
   PENDING_TX_FLUSH,
@@ -9,6 +10,7 @@ import {
 import { Action, IAppState, Thunk } from '../../../domain/common';
 import { TopupWithAssetReply } from 'taxi-protobuf/generated/js/taxi_pb';
 import { Address } from '../../../domain/wallet/value-objects';
+import { unsetPendingTx } from './wallet';
 
 export function setAsset(asset: string): Thunk<IAppState, Action> {
   return (dispatch) => {
@@ -55,5 +57,32 @@ export function setTopup(
 ): Thunk<IAppState, Action> {
   return (dispatch) => {
     dispatch([PENDING_TX_SET_TAXI_TOPUP, { taxiTopup }]);
+  };
+}
+
+/**
+ * Flush both 'wallets[0].pendingTx' and 'transaction' state
+ * Unset badge
+ */
+export function flushTx(
+  onSuccess?: () => void,
+  onError?: (err: Error) => void
+): Thunk<IAppState, Action> {
+  return (dispatch) => {
+    dispatch(
+      // Unset 'wallets[0].pendingTx'
+      unsetPendingTx(
+        () => {
+          // Unset state 'transaction'
+          dispatch(flush());
+          browser.browserAction.setBadgeText({ text: '' }).catch((ignore) => ({}));
+          onSuccess?.();
+        },
+        (error) => {
+          console.error(error);
+          onError?.(error);
+        }
+      )
+    );
   };
 }

--- a/src/presentation/components/shell-popup.tsx
+++ b/src/presentation/components/shell-popup.tsx
@@ -3,8 +3,7 @@ import { useHistory } from 'react-router-dom';
 import ModalMenu from './modal-menu';
 import { DEFAULT_ROUTE } from '../routes/constants';
 import { AppContext } from '../../application/store/context';
-import { flush, unsetPendingTx, updateUtxosAssetsBalances } from '../../application/store/actions';
-import { browser } from 'webextension-polyfill-ts';
+import { flushTx, updateUtxosAssetsBalances } from '../../application/store/actions';
 
 interface Props {
   backBtnCb?: () => void;
@@ -38,16 +37,7 @@ const ShellPopUp: React.FC<Props> = ({
       dispatch(updateUtxosAssetsBalances(refreshCb, (error) => console.log(error)));
     }
     if (wallets[0].pendingTx) {
-      dispatch(
-        unsetPendingTx(
-          () => {
-            dispatch(flush());
-            browser.browserAction.setBadgeText({ text: '' }).catch((ignore) => ({}));
-            history.push(DEFAULT_ROUTE);
-          },
-          (err: Error) => console.log(err)
-        )
-      );
+      dispatch(flushTx(() => history.push(DEFAULT_ROUTE)));
     } else {
       history.push(DEFAULT_ROUTE);
     }

--- a/src/presentation/wallet/send/address-amount.tsx
+++ b/src/presentation/wallet/send/address-amount.tsx
@@ -9,7 +9,11 @@ import { DispatchOrThunk, IAppState } from '../../../domain/common';
 import Balance from '../../components/balance';
 import Button from '../../components/button';
 import ShellPopUp from '../../components/shell-popup';
-import { getAllAssetBalances, setAddressesAndAmount } from '../../../application/store/actions';
+import {
+  flushTx,
+  getAllAssetBalances,
+  setAddressesAndAmount,
+} from '../../../application/store/actions';
 import {
   imgPathMapMainnet,
   imgPathMapRegtest,
@@ -178,10 +182,14 @@ const AddressAmount: React.FC = () => {
   const assetTicker = state.assets[state.app.network.value][state.transaction.asset]?.ticker ?? '';
 
   const handleBackBtn = () => {
-    history.push({
-      pathname: TRANSACTIONS_ROUTE,
-      state: { assetHash: state.transaction.asset, assetTicker, assetsBalance: balances },
-    });
+    dispatch(
+      flushTx(() => {
+        history.push({
+          pathname: TRANSACTIONS_ROUTE,
+          state: { assetHash: state.transaction.asset, assetTicker, assetsBalance: balances },
+        });
+      })
+    );
   };
 
   useEffect(() => {

--- a/src/presentation/wallet/send/confirmation.tsx
+++ b/src/presentation/wallet/send/confirmation.tsx
@@ -26,10 +26,12 @@ const Confirmation: React.FC = () => {
 
   const handleSend = () => history.push(SEND_END_OF_FLOW_ROUTE);
   const handleBackBtn = () => {
-    history.push({
-      pathname: SEND_CHOOSE_FEE_ROUTE,
-      state: { changeAddress: state.changeAddress },
-    });
+    if (state?.changeAddress) {
+      history.push({
+        pathname: SEND_CHOOSE_FEE_ROUTE,
+        state: { changeAddress: state.changeAddress },
+      });
+    }
   };
 
   return (
@@ -39,12 +41,12 @@ const Confirmation: React.FC = () => {
       className="h-popupContent container pb-20 mx-auto text-center bg-bottom bg-no-repeat"
       currentPage="Confirmation"
     >
-      <h1 className="text-2xl">{assets[app.network.value][sendAsset].name}</h1>
+      <h1 className="text-2xl">{assets[app.network.value][sendAsset]?.name}</h1>
       <img
         className="w-11 mt-0.5 block mx-auto mb-2"
         src={
           app.network.value === 'regtest'
-            ? imgPathMapRegtest[assets[app.network.value][sendAsset].ticker] ??
+            ? imgPathMapRegtest[assets[app.network.value][sendAsset]?.ticker] ??
               imgPathMapRegtest['']
             : imgPathMapMainnet[sendAsset] ?? imgPathMapMainnet['']
         }
@@ -59,14 +61,14 @@ const Confirmation: React.FC = () => {
       <div className="bg-gradient-to-r from-secondary to-primary flex flex-row items-center justify-between h-12 px-4 mt-4 rounded-full">
         <span className="text-lg font-medium">Amount</span>
         <span className="text-base font-medium text-white">
-          {fromSatoshiStr(sendAmount)} {assets[app.network.value][sendAsset].ticker}
+          {fromSatoshiStr(sendAmount)} {assets[app.network.value][sendAsset]?.ticker}
         </span>
       </div>
 
       <div className="flex flex-row items-end justify-between px-3 mt-10">
         <span className="text-lg font-medium">Fee</span>
         <span className="font-regular text-base">
-          {fromSatoshiStr(feeAmount)} {assets[app.network.value][feeAsset].ticker}
+          {fromSatoshiStr(feeAmount)} {assets[app.network.value][feeAsset]?.ticker}
         </span>
       </div>
 

--- a/src/presentation/wallet/send/payment-success.tsx
+++ b/src/presentation/wallet/send/payment-success.tsx
@@ -7,12 +7,7 @@ import { browser } from 'webextension-polyfill-ts';
 import { esploraURL } from '../../utils';
 import { DEFAULT_ROUTE } from '../../routes/constants';
 import { AppContext } from '../../../application/store/context';
-import {
-  deriveNewAddress,
-  flush,
-  setAddress,
-  unsetPendingTx,
-} from '../../../application/store/actions';
+import { deriveNewAddress, flushTx, setAddress } from '../../../application/store/actions';
 import { Address } from '../../../domain/wallet/value-objects';
 
 interface LocationState {
@@ -39,15 +34,7 @@ const PaymentSuccess: React.FC = () => {
 
   // Cleanup and change address derivation
   useEffect(() => {
-    const onSuccess = () => {
-      dispatch(
-        unsetPendingTx(() => {
-          browser.browserAction.setBadgeText({ text: '' }).catch((ignore) => ({}));
-          dispatch(flush());
-        }, console.error)
-      );
-    };
-
+    const onSuccess = () => dispatch(flushTx());
     // persist change addresses before unsetting the pending tx
     if (state.changeAddress?.value) {
       dispatch(

--- a/src/presentation/wallet/transactions/index.tsx
+++ b/src/presentation/wallet/transactions/index.tsx
@@ -64,7 +64,7 @@ const Transactions: React.FC = () => {
 
   /**
 
-  /**
+   /**
    * Log errors if any
    */
   useEffect(() => {


### PR DESCRIPTION
- Recover UI after Confirmation screen closed and reopened 

- Flush tx if going back from AddressAmount
  - Extracted logic new action `flushTx` that flush both `wallets[0].pendingTx` and `transaction` state, and unset badge.