### PR TITLE
WIP Show popup on Enable API 

### DIFF
--- a/src/presentation/connect/enable.tsx
+++ b/src/presentation/connect/enable.tsx
@@ -1,18 +1,29 @@
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 import Button from '../components/button';
 import ShellPopUp from '../components/shell-popup';
 
+function useQuery(key: string) {
+  const queryString = new URLSearchParams(useLocation().search);
+  return queryString.get(key);
+}
+
 const ConnectEnable: React.FC = () => {
-  const permissions = ['View this address of your account'];
-  const websiteTitle = 'Sideshift.ai';
-  const handleReject = () => console.log('reject');
-  const handleAccept = () => console.log('accept');
+  const hostname = useQuery('origin');
+
+  const permissions = ['View addresses of your wallet'];
+  const websiteTitle = hostname;
+  const handleReject = () => window.close();
+  const handleAccept = () => {
+    console.log('accept');
+    window.close();
+  };
 
   return (
     <ShellPopUp
-      backgroundImagePath="/assets/images/popup/bg-sm.png"
+      hasBackBtn={false}
       className="h-popupContent container pb-20 mx-auto text-center bg-bottom bg-no-repeat"
-      currentPage="Spend"
+      currentPage="Enable"
     >
       <h1 className="mt-8 text-2xl font-medium">{websiteTitle}</h1>
 

--- a/src/presentation/connect/spend.tsx
+++ b/src/presentation/connect/spend.tsx
@@ -1,17 +1,28 @@
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 import Button from '../components/button';
 import ShellPopUp from '../components/shell-popup';
 
+function useQuery(key: string) {
+  const queryString = new URLSearchParams(useLocation().search);
+  return queryString.get(key);
+}
+
 const ConnectSpend: React.FC = () => {
+  const hostname = useQuery('origin');
+
   const assetTicker = 'L-BTC';
   const assetAmount = '0.007';
-  const websiteTitle = 'Sideshift.ai';
-  const handleReject = () => console.log('reject');
-  const handleAccept = () => console.log('accept');
+  const websiteTitle = hostname;
+  const handleReject = () => window.close();
+  const handleAccept = () => {
+    console.log('accept');
+    window.close();
+  };
 
   return (
     <ShellPopUp
-      backgroundImagePath="/assets/images/popup/bg-sm.png"
+      hasBackBtn={false}
       className="h-popupContent container pb-20 mx-auto text-center bg-bottom bg-no-repeat"
       currentPage="Spend"
     >

--- a/src/presentation/routes/constants.ts
+++ b/src/presentation/routes/constants.ts
@@ -1,3 +1,7 @@
+// Connect
+const CONNECT_ENABLE_ROUTE = '/enable';
+const CONNECT_SPEND_ROUTE = '/spend';
+
 // Onboarding
 const INITIALIZE_WELCOME_ROUTE = '/initialize/welcome';
 const INITIALIZE_CREATE_PASSWORD_ROUTE = '/initialize/create-password';
@@ -41,6 +45,9 @@ const SETTINGS_CREDITS_ROUTE = '/settings/info/credits';
 const SETTINGS_TERMS_ROUTE = '/settings/info/terms-of-service';
 
 export {
+  //Connect
+  CONNECT_ENABLE_ROUTE,
+  CONNECT_SPEND_ROUTE,
   // Onboarding
   INITIALIZE_WELCOME_ROUTE,
   INITIALIZE_CREATE_PASSWORD_ROUTE,

--- a/src/presentation/routes/guards.tsx
+++ b/src/presentation/routes/guards.tsx
@@ -1,6 +1,9 @@
 import React, { useContext } from 'react';
-import { Route, Redirect, RouteProps, RouteComponentProps } from 'react-router-dom';
+import { Route, Redirect, RouteProps, RouteComponentProps, useParams } from 'react-router-dom';
 import { AppContext } from '../../application/store/context';
+import { CONNECT_ENABLE_ROUTE, CONNECT_SPEND_ROUTE } from './constants';
+
+const ALLOWED_REDIRECT_ROUTE = [CONNECT_ENABLE_ROUTE, CONNECT_SPEND_ROUTE];
 
 /**
  * A wrapper for <Route> that redirects to the login screen if you're not yet authenticated
@@ -18,11 +21,20 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ comp: Component,
   const appCtx = useContext(AppContext);
   const isAuthenticated = appCtx?.[0]?.app.isAuthenticated;
 
+  // we check if an optional param is given
+  // redirect to enable and spend connect page
+  const { id }: { id?: string } = useParams();
+  const idWithSlash = `/${id}`;
+
   return (
     <Route
       {...rest}
       render={(props) =>
-        isAuthenticated ? (
+        // TODO check if the website is enabled
+        // before redirecting to spend page
+        idWithSlash && ALLOWED_REDIRECT_ROUTE.includes(idWithSlash) ? (
+          <Redirect to={{ pathname: idWithSlash }} />
+        ) : isAuthenticated ? (
           <Component {...props} />
         ) : (
           <Redirect

--- a/src/presentation/routes/index.tsx
+++ b/src/presentation/routes/index.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Switch, Route } from 'react-router-dom';
 import { ProtectedRoute } from './guards';
 import {
+  CONNECT_ENABLE_ROUTE,
+  CONNECT_SPEND_ROUTE,
   INITIALIZE_WELCOME_ROUTE,
   INITIALIZE_SELECT_ACTION_ROUTE,
   INITIALIZE_CREATE_PASSWORD_ROUTE,
@@ -32,6 +34,10 @@ import {
   SEND_PAYMENT_SUCCESS_ROUTE,
   SEND_PAYMENT_ERROR_ROUTE,
 } from './constants';
+
+// Connect
+import ConnectEnable from '../connect/enable';
+import ConnectSpend from '../connect/spend';
 
 // Onboarding
 import Welcome from '../onboarding/welcome';
@@ -102,6 +108,9 @@ const Routes: React.FC = () => {
       <ProtectedRoute exact path={SETTINGS_TERMS_ROUTE} comp={SettingsTerms} />
       {/*Login*/}
       <Route exact path={LOGIN_ROUTE} component={LogIn} />
+      {/*Connect*/}
+      <Route exact path={CONNECT_ENABLE_ROUTE} component={ConnectEnable} />
+      <Route exact path={CONNECT_SPEND_ROUTE} component={ConnectSpend} />
     </Switch>
   );
 };


### PR DESCRIPTION
This PR lays down the intial ground work to get the injected API to wire up and show a popup window.

Is not possible to programmatically open the ShellPopup because disallowed by the browser themself. The trick I found in the Metamask/Liquality codebase is to create a new window that resemble the size of the extension with `browser.windows.create`

The I use the URL params to switch in the router's `Guard` component in case of `/enable` or `/spend` route: since `ConnectEnable` and `ConnectSpend` lives outside the ShelPopup, I dropped the back button from the UI screens.

### What's missing?

I was able to wire up and send via query string the hostname that is requesting the API. What is misisng is a way to wire those two views all the way down to the background script﻿ to communicate the repsonse of either reject or accept.

- Add Event emitter to communicate via message passing or window DOM events
- Understand how to unlock the wallet properly: we show the unlock page in the create popup window? or we ask the user to politely open the ShellPopup to actually review the transaction and use the "Send" flow for normal transactions?



