### PR TITLE
WIP: Polling utxos

### DIFF
--- a/src/application/backend.ts
+++ b/src/application/backend.ts
@@ -60,30 +60,8 @@ export default class Backend {
 
       port.onMessage.addListener(
         async ({ id, name, params }: { id: string; name: string; params: any[] }) => {
-          console.log('name!!!!', name);
-          switch (name) {
-            case 'startAlarmUtxosAssets':
-              try {
-                const nowPlus5sec = Date.now() + 5000;
-                browser.alarms.create('updateUtxosAssets', {
-                  when: nowPlus5sec,
-                  periodInMinutes: 1,
-                });
-                browser.alarms.onAlarm.addListener(async (alarm) => {
-                  console.log(alarm.name);
-                  if (alarm.name === 'updateUtxosAssets') {
-                    console.log('alarm updateUtxos !!!!!!');
-                    const utxos = await updateUtxos();
-                    await updateAllAssetInfos();
-                    console.log('id', id);
-                    return handleResponse(id, { utxos });
-                  }
-                });
-                return handleResponse(id, { message: 'Polling of utxos and assets started' });
-              } catch (e: any) {
-                return handleError(id, e);
-              }
 
+          switch (name) {
             case Marina.prototype.getNetwork.name:
               try {
                 const network = await getCurrentNetwork();
@@ -285,7 +263,7 @@ async function getCoins(): Promise<UtxoInterface[]> {
   return Array.from(wallet.utxoMap.values());
 }
 
-async function updateUtxos() {
+export async function updateUtxos() {
   const xpub = await getXpub();
   const addrs = xpub.getAddresses();
   const [app, wallet] = await Promise.all([repos.app.getApp(), repos.wallet.getOrCreateWallet()]);
@@ -316,10 +294,9 @@ async function updateUtxos() {
   });
   console.log('newMap', newMap);
   await repos.wallet.setUtxos(newMap);
-  return newMap;
 }
 
-async function updateAllAssetInfos() {
+export async function updateAllAssetInfos() {
   const [app, assets, wallet] = await Promise.all([
     repos.app.getApp(),
     repos.assets.getAssets(),

--- a/src/application/content-script.ts
+++ b/src/application/content-script.ts
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 import { browser, Runtime } from 'webextension-polyfill-ts';
 
-export default class Broker {
+class Broker {
   port: Runtime.Port;
   emitter: EventEmitter;
 

--- a/src/application/store/actions/index.ts
+++ b/src/application/store/actions/index.ts
@@ -36,24 +36,16 @@ export function updateUtxosAssetsBalances(
       app.network.value
     );
     dispatch(
-      setUtxos(
-        w.getAddresses(),
+      updateAllAssetInfos(
         () => {
           dispatch(
-            updateAllAssetInfos(
-              () => {
-                dispatch(
-                  getAllAssetBalances(
-                    (balances) => onSuccess?.(balances),
-                    (error) => onError?.(error)
-                  )
-                );
-              },
+            getAllAssetBalances(
+              (balances) => onSuccess?.(balances),
               (error) => onError?.(error)
             )
           );
         },
-        (error: Error) => onError?.(error)
+        (error) => onError?.(error)
       )
     );
   };

--- a/src/presentation/wallet/home/index.tsx
+++ b/src/presentation/wallet/home/index.tsx
@@ -24,7 +24,6 @@ import {
   lbtcAssetByNetwork,
 } from '../../../application/utils';
 import { waitAtLeast } from '../../../application/utils/common';
-import Broker from '../../../application/content-script';
 
 const Home: React.FC = () => {
   const history = useHistory();
@@ -61,7 +60,7 @@ const Home: React.FC = () => {
     // Update utxos set, owned assets and balances
     // Wait at least 800ms to avoid flickering
     waitAtLeast(
-      800,
+      50,
       new Promise((resolve, reject) => {
         dispatch(
           updateUtxosAssetsBalances(

--- a/src/presentation/wallet/send/payment-success.tsx
+++ b/src/presentation/wallet/send/payment-success.tsx
@@ -9,7 +9,6 @@ import { DEFAULT_ROUTE } from '../../routes/constants';
 import { AppContext } from '../../../application/store/context';
 import { deriveNewAddress, flushTx, setAddress } from '../../../application/store/actions';
 import { Address } from '../../../domain/wallet/value-objects';
-import Broker from '../../../application/content-script';
 
 interface LocationState {
   changeAddress?: Address;


### PR DESCRIPTION
The basic idea is to use the browser storage as a way to communicate between the background script and the react UI.

The BG scripts does polling to the network and writes to storage and the React does polling to storage and writes to his react state.

`browser.alarms` cannot be run less than a minute, therefore I opted out to use it to "keep alive"  a `setInterval` that runs every 5 seconds or so.

That's an idea and only way to make sure we are always up to date. Alternative I see is to use serviceWorkers to listen to bacgound script events and make sure we update the react state accordingly.