### PR TITLE
Implement redux-persist versioning 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marina",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "scripts": {
     "build": "npm run clean && npm run copy-assets && run-p build:**",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marina",
-  "version": "0.2.2",
+  "version": "0.2.1",
   "private": true,
   "scripts": {
     "build": "npm run clean && npm run copy-assets && run-p build:**",

--- a/src/application/redux/reducers/app-reducer.ts
+++ b/src/application/redux/reducers/app-reducer.ts
@@ -4,7 +4,7 @@ import { IError } from '../../../domain/common';
 import { AnyAction } from 'redux';
 import * as ACTION_TYPES from '../actions/action-types';
 
-const appInitState: IApp = {
+export const appInitState: IApp = {
   isOnboardingCompleted: false,
   isAuthenticated: false,
   isWalletVerified: false,

--- a/src/application/redux/reducers/asset-reducer.ts
+++ b/src/application/redux/reducers/asset-reducer.ts
@@ -2,7 +2,7 @@ import { AnyAction } from 'redux';
 import { IAssets } from '../../../domain/assets';
 import * as ACTION_TYPES from '../actions/action-types';
 
-const assetInitState: IAssets = {
+export const assetInitState: IAssets = {
   ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2: {
     name: 'Tether USD',
     precision: 8,

--- a/src/application/redux/reducers/connect-data-reducer.ts
+++ b/src/application/redux/reducers/connect-data-reducer.ts
@@ -3,7 +3,7 @@ import { AnyAction } from 'redux';
 import * as ACTION_TYPES from '../actions/action-types';
 import { ConnectData, newEmptyConnectData } from '../../../domain/connect';
 
-const connectDataInitState: ConnectData = newEmptyConnectData();
+export const connectDataInitState: ConnectData = newEmptyConnectData();
 
 export function connectDataReducer(
   state: ConnectData = connectDataInitState,

--- a/src/application/redux/reducers/index.ts
+++ b/src/application/redux/reducers/index.ts
@@ -5,7 +5,7 @@ import { transactionInitState, transactionReducer, TransactionState } from './tr
 import { txsHistoryReducer, txsHistoryInitState } from './txs-history-reducer';
 import { AnyAction, combineReducers, Reducer } from 'redux';
 import { appInitState, appReducer } from './app-reducer';
-import { connectDataReducer } from './connect-data-reducer';
+import { connectDataReducer, connectDataInitState } from './connect-data-reducer';
 import { Storage } from 'redux-persist';
 import { parse, stringify } from '../../utils/browser-storage-converters';
 import { browser } from 'webextension-polyfill-ts';
@@ -14,7 +14,7 @@ import { IApp } from '../../../domain/app';
 import { TxsHistoryByNetwork } from '../../../domain/transaction';
 import { IWallet } from '../../../domain/wallet';
 import { taxiReducer, TaxiState, taxiInitState } from './taxi-reducer';
-import { ConnectData, newEmptyConnectData } from '../../../domain/connect';
+import { ConnectData } from '../../../domain/connect';
 import { IAssets } from '../../../domain/assets';
 import { PersistConfig } from 'redux-persist/lib/types';
 
@@ -112,7 +112,7 @@ const marinaReducer = combineReducers({
     key: 'connect',
     whitelist: ['enabledSites'],
     version: 1,
-    initialState: newEmptyConnectData(),
+    initialState: connectDataInitState,
   }),
 });
 

--- a/src/application/redux/reducers/index.ts
+++ b/src/application/redux/reducers/index.ts
@@ -43,10 +43,12 @@ function createLocalStorageConfig<S>(
     version,
     whitelist,
     blacklist,
-    migrate: (state: any) => ({
-      ...state,
-      ...initialState,
-    }),
+    migrate: (state: any) => {
+      return Promise.resolve({
+        ...state,
+        ...initialState,
+      });
+    },
   };
 }
 

--- a/src/application/redux/reducers/index.ts
+++ b/src/application/redux/reducers/index.ts
@@ -1,10 +1,10 @@
-import { assetReducer } from './asset-reducer';
+import { assetInitState, assetReducer } from './asset-reducer';
 import { onboardingReducer } from './onboarding-reducer';
-import { walletReducer } from './wallet-reducer';
-import { transactionReducer, TransactionState } from './transaction-reducer';
-import { txsHistoryReducer } from './txs-history-reducer';
+import { walletInitState, walletReducer } from './wallet-reducer';
+import { transactionInitState, transactionReducer, TransactionState } from './transaction-reducer';
+import { txsHistoryReducer, txsHistoryInitState } from './txs-history-reducer';
 import { AnyAction, combineReducers, Reducer } from 'redux';
-import { appReducer } from './app-reducer';
+import { appInitState, appReducer } from './app-reducer';
 import { connectDataReducer } from './connect-data-reducer';
 import { Storage } from 'redux-persist';
 import { parse, stringify } from '../../utils/browser-storage-converters';
@@ -13,9 +13,10 @@ import persistReducer, { PersistPartial } from 'redux-persist/es/persistReducer'
 import { IApp } from '../../../domain/app';
 import { TxsHistoryByNetwork } from '../../../domain/transaction';
 import { IWallet } from '../../../domain/wallet';
-import { taxiReducer, TaxiState } from './taxi-reducer';
-import { ConnectData } from '../../../domain/connect';
+import { taxiReducer, TaxiState, taxiInitState } from './taxi-reducer';
+import { ConnectData, newEmptyConnectData } from '../../../domain/connect';
 import { IAssets } from '../../../domain/assets';
+import { PersistConfig } from 'redux-persist/lib/types';
 
 const browserLocalStorage: Storage = {
   getItem: async (key: string) => {
@@ -29,59 +30,87 @@ const browserLocalStorage: Storage = {
   removeItem: async (key: string) => browser.storage.local.remove(key),
 };
 
-const createLocalStorageConfig = (
+function createLocalStorageConfig<S>(
+  initialState: S,
   key: string,
   whitelist?: string[],
   blacklist?: string[],
   version = 0
-) => ({
-  key,
-  storage: browserLocalStorage,
-  version,
-  whitelist,
-  blacklist,
-});
+): PersistConfig<S, any, any, any> {
+  return {
+    key,
+    storage: browserLocalStorage,
+    version,
+    whitelist,
+    blacklist,
+    migrate: (state: any) => ({
+      ...state,
+      ...initialState,
+    }),
+  };
+}
 
 // custom persist reducer function
 function persist<S extends any>(opts: {
   reducer: Reducer<S, AnyAction>;
+  initialState: S;
   key: string;
   whitelist?: string[];
   blacklist?: string[];
   version?: number;
 }): Reducer<S & PersistPartial, AnyAction> {
   return persistReducer(
-    createLocalStorageConfig(opts.key, opts.whitelist, opts.blacklist, opts.version),
+    createLocalStorageConfig(
+      opts.initialState,
+      opts.key,
+      opts.whitelist,
+      opts.blacklist,
+      opts.version
+    ),
     opts.reducer
   );
 }
 
 const marinaReducer = combineReducers({
-  app: persist<IApp>({ reducer: appReducer, key: 'app', version: 1 }),
-  assets: persist<IAssets>({ reducer: assetReducer, key: 'assets', version: 1 }),
+  app: persist<IApp>({ reducer: appReducer, key: 'app', version: 1, initialState: appInitState }),
+  assets: persist<IAssets>({
+    reducer: assetReducer,
+    key: 'assets',
+    version: 1,
+    initialState: assetInitState,
+  }),
   onboarding: onboardingReducer,
   transaction: persist<TransactionState>({
     reducer: transactionReducer,
     key: 'transaction',
     version: 1,
+    initialState: transactionInitState,
   }),
   txsHistory: persist<TxsHistoryByNetwork>({
     reducer: txsHistoryReducer,
     key: 'txsHistory',
     version: 1,
+    initialState: txsHistoryInitState,
   }),
   wallet: persist<IWallet>({
     reducer: walletReducer,
     key: 'wallet',
     blacklist: ['deepRestorer'],
     version: 1,
+    initialState: walletInitState,
   }),
-  taxi: persist<TaxiState>({ reducer: taxiReducer, key: 'taxi', version: 1 }),
+  taxi: persist<TaxiState>({
+    reducer: taxiReducer,
+    key: 'taxi',
+    version: 1,
+    initialState: taxiInitState,
+  }),
   connect: persist<ConnectData>({
     reducer: connectDataReducer,
     key: 'connect',
     whitelist: ['enabledSites'],
     version: 1,
+    initialState: newEmptyConnectData(),
   }),
 });
 

--- a/src/application/redux/reducers/taxi-reducer.ts
+++ b/src/application/redux/reducers/taxi-reducer.ts
@@ -4,11 +4,14 @@ export interface TaxiState {
   taxiAssets: string[];
 }
 
-const initState: TaxiState = {
+export const taxiInitState: TaxiState = {
   taxiAssets: [],
 };
 
-export function taxiReducer(state: TaxiState = initState, { type, payload }: AnyAction): TaxiState {
+export function taxiReducer(
+  state: TaxiState = taxiInitState,
+  { type, payload }: AnyAction
+): TaxiState {
   switch (type) {
     case SET_TAXI_ASSETS:
       return { ...state, taxiAssets: payload };

--- a/src/application/redux/reducers/transaction-reducer.ts
+++ b/src/application/redux/reducers/transaction-reducer.ts
@@ -16,7 +16,7 @@ export interface TransactionState {
   feeChangeAddress?: Address;
 }
 
-const transactionInitState: TransactionState = {
+export const transactionInitState: TransactionState = {
   step: 'empty',
   sendAsset: '',
   sendAddress: undefined,

--- a/src/application/redux/reducers/txs-history-reducer.ts
+++ b/src/application/redux/reducers/txs-history-reducer.ts
@@ -2,7 +2,7 @@ import * as ACTION_TYPES from '../actions/action-types';
 import { TxDisplayInterface, TxsHistoryByNetwork } from '../../../domain/transaction';
 import { AnyAction } from 'redux';
 
-const txsHistoryInitState: TxsHistoryByNetwork = { regtest: {}, liquid: {} };
+export const txsHistoryInitState: TxsHistoryByNetwork = { regtest: {}, liquid: {} };
 
 export function txsHistoryReducer(
   state: TxsHistoryByNetwork = txsHistoryInitState,

--- a/src/application/redux/reducers/wallet-reducer.ts
+++ b/src/application/redux/reducers/wallet-reducer.ts
@@ -5,7 +5,7 @@ import { IWallet } from '../../../domain/wallet';
 import { AnyAction } from 'redux';
 import { UtxoInterface } from 'ldk';
 
-const initialStateWallet: IWallet = {
+export const walletInitState: IWallet = {
   restorerOpts: {
     lastUsedExternalIndex: 0,
     lastUsedInternalIndex: 0,
@@ -22,7 +22,7 @@ const initialStateWallet: IWallet = {
 };
 
 export function walletReducer(
-  state: IWallet = initialStateWallet,
+  state: IWallet = walletInitState,
   { type, payload }: AnyAction
 ): IWallet {
   switch (type) {


### PR DESCRIPTION
**This PR adds the `version` field to persisted reducers.**

- improve `persist` function type and syntax.
- add the `version` field as a parameter in `persist` (initialized to version 1, the current release is 0). Basically, it's a constant number stored in the reducer.
- the migration strategy is the following: if the rehydrated reducer has a version greater than the one defined in scheme, we'll use the `migrate` function defined in `localStorageConfig`.
- next, we should use [MigrationsManifest](https://github.com/rt2zz/redux-persist/blob/master/docs/api.md#createmigratemigrations-config) to implement custom migration for each version number.

it closes #191 

@tiero please review