### PR TITLE
Fix explorer links and blindPset function

### DIFF
--- a/src/application/redux/containers/end-of-flow.container.ts
+++ b/src/application/redux/containers/end-of-flow.container.ts
@@ -9,6 +9,7 @@ const mapStateToProps = (state: RootReducerState): EndOfFlowProps => ({
   restorerOpts: state.wallet.restorerOpts,
   pset: state.transaction.pset,
   explorerURL: getExplorerURLSelector(state),
+  recipientAddress: state.transaction.sendAddress?.value,
 });
 
 const SendEndOfFlow = connect(mapStateToProps)(EndOfFlow);

--- a/src/application/redux/containers/payment-success.container.ts
+++ b/src/application/redux/containers/payment-success.container.ts
@@ -5,7 +5,7 @@ import PaymentSuccessView, {
 } from '../../../presentation/wallet/send/payment-success';
 
 const mapStateToProps = (state: RootReducerState): PaymentSuccessProps => ({
-  network: state.app.network,
+  electrsExplorerURL: state.app.explorerByNetwork[state.app.network].electrsURL,
 });
 
 const PaymentSuccess = connect(mapStateToProps)(PaymentSuccessView);

--- a/src/application/utils/transaction.ts
+++ b/src/application/utils/transaction.ts
@@ -40,13 +40,14 @@ export async function blindAndSignPset(
   mnemonic: string,
   restorerOpts: StateRestorerOpts,
   chain: string,
-  psetBase64: string
+  psetBase64: string,
+  recipientAddresses: string[]
 ): Promise<string> {
   const mnemo = await mnemonicWallet(mnemonic, restorerOpts, chain);
 
   const outputAddresses = (await mnemo.getAddresses()).map((a) => a.confidentialAddress);
 
-  const outputPubKeys = outPubKeysMap(psetBase64, outputAddresses);
+  const outputPubKeys = outPubKeysMap(psetBase64, outputAddresses.concat(recipientAddresses));
   const outputsToBlind = Array.from(outputPubKeys.keys());
 
   const blindedPset: string = await mnemo.blindPset(psetBase64, outputsToBlind, outputPubKeys);

--- a/src/presentation/components/balance.tsx
+++ b/src/presentation/components/balance.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import cx from 'classnames';
 import { browser } from 'webextension-polyfill-ts';
-import { esploraURL } from '../utils';
 import { useSelector } from 'react-redux';
 import { RootReducerState } from '../../domain/common';
 
@@ -22,11 +21,13 @@ const Balance: React.FC<Props> = ({
   assetTicker,
   assetHash,
 }) => {
-  const network = useSelector((state: RootReducerState) => state.app.network);
+  const electrsURL = useSelector(
+    (state: RootReducerState) => state.app.explorerByNetwork[state.app.network].electrsURL
+  );
 
   const handleOpenExplorer = () =>
     browser.tabs.create({
-      url: `${esploraURL[network]}/asset/${assetHash}`,
+      url: `${electrsURL}/asset/${assetHash}`,
       active: false,
     });
 

--- a/src/presentation/utils/constants.ts
+++ b/src/presentation/utils/constants.ts
@@ -1,4 +1,0 @@
-export const esploraURL: Record<string, string> = {
-  regtest: 'http://localhost:5001',
-  liquid: 'https://blockstream.info/liquid',
-};

--- a/src/presentation/utils/index.ts
+++ b/src/presentation/utils/index.ts
@@ -1,2 +1,1 @@
-export * from './constants';
 export * from './format';

--- a/src/presentation/wallet/send/end-of-flow.tsx
+++ b/src/presentation/wallet/send/end-of-flow.tsx
@@ -18,6 +18,7 @@ export interface EndOfFlowProps {
   restorerOpts: StateRestorerOpts;
   pset?: string;
   explorerURL: string;
+  recipientAddress?: string;
 }
 
 const EndOfFlow: React.FC<EndOfFlowProps> = ({
@@ -26,6 +27,7 @@ const EndOfFlow: React.FC<EndOfFlowProps> = ({
   pset,
   restorerOpts,
   explorerURL,
+  recipientAddress,
 }) => {
   const history = useHistory();
   const [isModalUnlockOpen, showUnlockModal] = useState<boolean>(true);
@@ -35,7 +37,7 @@ const EndOfFlow: React.FC<EndOfFlowProps> = ({
 
   const handleUnlock = async (password: string) => {
     let tx = '';
-    if (!pset) return;
+    if (!pset || !recipientAddress) return;
     try {
       const pass = createPassword(password);
       if (!match(password, wallet.passwordHash)) {
@@ -44,7 +46,7 @@ const EndOfFlow: React.FC<EndOfFlowProps> = ({
 
       const mnemonic = decrypt(wallet.encryptedMnemonic, pass);
 
-      tx = await blindAndSignPset(mnemonic, restorerOpts, network, pset);
+      tx = await blindAndSignPset(mnemonic, restorerOpts, network, pset, [recipientAddress]);
 
       const txid = await broadcastTx(explorerURL, tx);
       history.push({

--- a/src/presentation/wallet/send/payment-success.tsx
+++ b/src/presentation/wallet/send/payment-success.tsx
@@ -4,11 +4,9 @@ import ShellPopUp from '../../components/shell-popup';
 import useLottieLoader from '../../hooks/use-lottie-loader';
 import Button from '../../components/button';
 import { browser } from 'webextension-polyfill-ts';
-import { esploraURL } from '../../utils';
 import { DEFAULT_ROUTE } from '../../routes/constants';
 import { useDispatch } from 'react-redux';
 import { flushPendingTx, updateTxs } from '../../../application/redux/actions/transaction';
-import { Network } from '../../../domain/network';
 import { ProxyStoreDispatch } from '../../../application/redux/proxyStore';
 import { updateUtxos } from '../../../application/redux/actions/utxos';
 
@@ -17,10 +15,10 @@ interface LocationState {
 }
 
 export interface PaymentSuccessProps {
-  network: Network;
+  electrsExplorerURL: string;
 }
 
-const PaymentSuccessView: React.FC<PaymentSuccessProps> = ({ network }) => {
+const PaymentSuccessView: React.FC<PaymentSuccessProps> = ({ electrsExplorerURL }) => {
   const { state } = useLocation<LocationState>();
   const dispatch = useDispatch<ProxyStoreDispatch>();
   const history = useHistory();
@@ -31,7 +29,7 @@ const PaymentSuccessView: React.FC<PaymentSuccessProps> = ({ network }) => {
 
   const handleOpenExplorer = () =>
     browser.tabs.create({
-      url: `${esploraURL[network]}/tx/${state.txid}`,
+      url: `${electrsExplorerURL}/tx/${state.txid}`,
       active: false,
     });
 


### PR DESCRIPTION
- the asset's logo link now uses a redux selector to get the right explorer URL.
- the `payment-success` page uses a redux selector to get electrs URL.

it closes #202 

- blindAndSignPset function fix: now the tx blinds the recipient output.

it closes #199 

@tiero please review