### PR TITLE
Fix Marina X Firefox-based browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "decimal.js": "^10.2.1",
     "formik": "^2.2.6",
     "google-protobuf": "^3.15.8",
-    "ldk": "https://github.com/louisinger/ldk.git#blech32",
+    "ldk": "^0.3.9",
     "lodash.debounce": "^4.0.8",
     "lottie-web": "^5.7.8",
     "marina-provider": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "decimal.js": "^10.2.1",
     "formik": "^2.2.6",
     "google-protobuf": "^3.15.8",
-    "ldk": "^0.3.7",
+    "ldk": "https://github.com/louisinger/ldk.git#blech32",
     "lodash.debounce": "^4.0.8",
     "lottie-web": "^5.7.8",
     "marina-provider": "^1.2.0",

--- a/src/application/backend.ts
+++ b/src/application/backend.ts
@@ -592,12 +592,11 @@ export function fetchAndUpdateUtxos(): ThunkAction<void, RootReducerState, any, 
           const outpoint = toStringOutpoint(utxo);
           const skip = wallet.utxoMap[outpoint] !== undefined;
 
-          if (skip) skippedOutpoints.push(toStringOutpoint(utxo))
+          if (skip) skippedOutpoints.push(toStringOutpoint(utxo));
 
-          return skip
+          return skip;
         }
       );
-
 
       let utxoIterator = await utxos.next();
       while (!utxoIterator.done) {

--- a/src/application/broker.ts
+++ b/src/application/broker.ts
@@ -106,7 +106,9 @@ export default class Broker {
 
       for (const ev of events) {
         window.dispatchEvent(
-          new CustomEvent(`marina_event_${ev.type.toLowerCase()}`, { detail: stringify(ev.payload) })
+          new CustomEvent(`marina_event_${ev.type.toLowerCase()}`, {
+            detail: stringify(ev.payload),
+          })
         );
       }
     });

--- a/src/application/broker.ts
+++ b/src/application/broker.ts
@@ -14,6 +14,7 @@ import { UtxoInterface } from 'ldk';
 import { TxsHistory } from '../domain/transaction';
 import { AnyAction } from 'redux';
 import { Network } from '../domain/network';
+import { stringify } from './utils/browser-storage-converters';
 
 interface Message {
   id: string;
@@ -105,14 +106,14 @@ export default class Broker {
 
       for (const ev of events) {
         window.dispatchEvent(
-          new CustomEvent(`marina_event_${ev.type.toLowerCase()}`, { detail: ev.payload })
+          new CustomEvent(`marina_event_${ev.type.toLowerCase()}`, { detail: stringify(ev.payload) })
         );
       }
     });
   }
 
   private sendMsgToInjectScript(message: Message) {
-    window.dispatchEvent(new CustomEvent(message.id, { detail: message.payload }));
+    window.dispatchEvent(new CustomEvent(message.id, { detail: stringify(message.payload) }));
   }
 
   start() {

--- a/src/application/proxy.ts
+++ b/src/application/proxy.ts
@@ -1,4 +1,5 @@
 import { MarinaEventType } from 'marina-provider';
+import { parse } from './utils/browser-storage-converters';
 
 type EventListenerID = string;
 
@@ -29,7 +30,7 @@ export default class WindowProxy {
       window.addEventListener(
         id,
         (event: Event) => {
-          const response = (event as CustomEvent).detail;
+          const response = parse((event as CustomEvent).detail);
 
           if (!response.success) return reject(new Error(response.error));
           return resolve(response.data);
@@ -73,7 +74,7 @@ export default class WindowProxy {
   // start the window listner for a given marina event type
   private startWindowListener(type: MarinaEventType) {
     window.addEventListener(`marina_event_${type.toLowerCase()}`, (event: Event) => {
-      const payload = (event as CustomEvent).detail;
+      const payload = parse((event as CustomEvent).detail);
       for (const eventListener of this.eventListeners[type]) {
         eventListener.listener(payload);
       }

--- a/src/application/redux/selectors/wallet.selector.ts
+++ b/src/application/redux/selectors/wallet.selector.ts
@@ -3,7 +3,6 @@ import { RootReducerState } from '../../../domain/common';
 
 export function masterPubKeySelector(state: RootReducerState): MasterPublicKey {
   const { masterBlindingKey, masterXPub } = state.wallet;
-  console.log(state.wallet);
   const network = state.app.network;
   const pubKeyWallet = new MasterPublicKey({
     chain: network,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7041,15 +7041,16 @@ lcid@^3.0.0:
   dependencies:
     invert-kv "^3.0.0"
 
-"ldk@https://github.com/louisinger/ldk.git#blech32":
-  version "0.3.7"
-  resolved "https://github.com/louisinger/ldk.git#2514ac681b63e12d251df514c0c4390238dfdad1"
+ldk@^0.3.9:
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/ldk/-/ldk-0.3.9.tgz#50ec067e31a2d8d235dc0e072a877e00b7133d15"
+  integrity sha512-SSSpS5r/Fbj5ZFseZcLsud9ErP5p/5dclmptfaI05bnejs5Iys47t0IggBGBhrsLggfmy7119swJMs0hyA2VXA==
   dependencies:
     axios "^0.21.1"
     bip32 "^2.0.6"
     bip39 "^3.0.3"
     bs58check "^2.1.2"
-    liquidjs-lib "https://github.com/louisinger/liquidjs-lib.git#blech32"
+    liquidjs-lib "^5.1.15"
     marina-provider "^1.0.0"
     slip77 "^0.1.1"
 
@@ -7099,9 +7100,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-"liquidjs-lib@https://github.com/louisinger/liquidjs-lib.git#blech32":
-  version "5.1.14"
-  resolved "https://github.com/louisinger/liquidjs-lib.git#3ac1dc52a35665ca9788bfc691f06fe8407b249a"
+liquidjs-lib@^5.1.15:
+  version "5.1.15"
+  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-5.1.15.tgz#43cf25006da11386e23561178a260264318467a9"
+  integrity sha512-shrt3KBUnFWoAAqBa5iyz8v62g1P9JIlMtvW+C2GH9J3HqYFV6Hs+Rx7OtNQ1z7xTNttPEbJMGn360JwIT9D0g==
   dependencies:
     "@vulpemventures/secp256k1-zkp" "^2.0.0"
     bech32 "^1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2377,9 +2377,12 @@ bitcoinjs-message@^2.2.0:
     secp256k1 "^3.0.1"
     varuint-bitcoin "^1.0.1"
 
-blech32@vulpemventures/blech32.git:
-  version "1.0.0"
-  resolved "https://codeload.github.com/vulpemventures/blech32/tar.gz/1c9acd89bdd2a2a5016fb942cf7d898579f84c8d"
+blech32@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/blech32/-/blech32-1.0.1.tgz#400b9a8953ff80164553a8cf58fece208762e16b"
+  integrity sha512-1/vr1wwB8jvfVCkLQMVXLaIyx7Lgxh/6IqVuQlSsCNzWNzU+64oXzOQ/9BRnN4GANjx9i0O3OSQonDlL4FraSA==
+  dependencies:
+    long "^4.0.0"
 
 blob-util@^2.0.2:
   version "2.0.2"
@@ -7038,16 +7041,15 @@ lcid@^3.0.0:
   dependencies:
     invert-kv "^3.0.0"
 
-ldk@^0.3.7:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/ldk/-/ldk-0.3.8.tgz#21413998bd72591f121221dee1f9adec82dd0b05"
-  integrity sha512-XTHVNKMq7cjZMpV/c28lN0LnhAEXhpZyiEYGHZdU2RmTh9eCxSK0LHg6cl4jP0nYVF+aYE5z8zQ/U8z1cbqo4w==
+"ldk@https://github.com/louisinger/ldk.git#blech32":
+  version "0.3.7"
+  resolved "https://github.com/louisinger/ldk.git#2514ac681b63e12d251df514c0c4390238dfdad1"
   dependencies:
     axios "^0.21.1"
     bip32 "^2.0.6"
     bip39 "^3.0.3"
     bs58check "^2.1.2"
-    liquidjs-lib "^5.1.14"
+    liquidjs-lib "https://github.com/louisinger/liquidjs-lib.git#blech32"
     marina-provider "^1.0.0"
     slip77 "^0.1.1"
 
@@ -7097,10 +7099,9 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-liquidjs-lib@^5.1.14:
+"liquidjs-lib@https://github.com/louisinger/liquidjs-lib.git#blech32":
   version "5.1.14"
-  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-5.1.14.tgz#105ab9cdc6c5723897d516d83e726424a2de8e25"
-  integrity sha512-Qwskr6J3+XeItzMG3c/mly0zMmGA9XYM10sBrlnc5/dwAENrUAof7AqWjBDEUk2GuVaEvpSUT+m2wO+vMrP8bQ==
+  resolved "https://github.com/louisinger/liquidjs-lib.git#3ac1dc52a35665ca9788bfc691f06fe8407b249a"
   dependencies:
     "@vulpemventures/secp256k1-zkp" "^2.0.0"
     bech32 "^1.1.2"
@@ -7108,7 +7109,7 @@ liquidjs-lib@^5.1.14:
     bip32 "^2.0.4"
     bip66 "^1.1.0"
     bitcoin-ops "^1.4.0"
-    blech32 vulpemventures/blech32.git
+    blech32 "^1.0.1"
     bs58check "^2.0.0"
     create-hash "^1.1.0"
     create-hmac "^1.1.3"


### PR DESCRIPTION
**This PR adds several fixes for Firefox**

- Use LDK 0.3.9 = LDK with [new blech32](https://github.com/vulpemventures/blech32/pull/10). We need it because Firefox does not support `asm.js` in content scripts;
- `stringify` and `parse` the `details` member in CustomEvent object (for security reasons, firefox does not handle objects payload in window.dispatchEvent).

PS: Cypress does not support "loadExtension" on firefox browsers. Not really a problem as we run it on chrome only.

it closes #165 

@tiero please review