### PR TITLE
Do not show the fee output as transaction's outbound

### DIFF
--- a/src/application/utils/transaction.ts
+++ b/src/application/utils/transaction.ts
@@ -156,13 +156,15 @@ function getTransfers(
 ): Transfer[] {
   const transfers: Transfer[] = [];
 
-  const addToTransfers = (amount: number, asset: string) => {
+  const addToTransfers = (amount: number, asset: string, isFee = false) => {
     const transferIndex = transfers.findIndex((t) => t.asset === asset);
 
     if (transferIndex >= 0) {
       transfers[transferIndex].amount += amount;
       return;
     }
+
+    if (isFee) return;
 
     transfers.push({
       amount,
@@ -179,10 +181,9 @@ function getTransfers(
   for (const output of vout) {
     if (
       !isBlindedOutputInterface(output) &&
-      walletScripts.includes(output.script) &&
-      output.script !== ''
+      (output.script === '' || walletScripts.includes(output.script))
     ) {
-      addToTransfers(output.value, output.asset);
+      addToTransfers(output.value, output.asset, output.script === '');
     }
   }
 

--- a/src/presentation/wallet/transactions/index.tsx
+++ b/src/presentation/wallet/transactions/index.tsx
@@ -146,8 +146,8 @@ const TransactionsView: React.FC<TransactionsProps> = ({
           </div>
           {modalTxDetails?.transfers.map((transfer, i) => (
             <div key={i}>
-              <p className="text-base font-medium">Amount</p>
-              <p className="text-xs font-light">
+              <p className="text-sm font-medium">{transfer.amount > 0 ? 'Inbound' : 'Outbound'}</p>
+              <p className="text-sm font-light">
                 {fromSatoshiStr(transfer.amount, assets[transfer.asset]?.precision)}{' '}
                 {assets[transfer.asset]?.ticker ?? transfer.asset.slice(0, 4)}
               </p>


### PR DESCRIPTION
- In `transactions.tsx` typo: "Outbound/Inbound" instead of "Amount".
- `getTransfers` function now filters the computed values in order to remove the fee "transfer" in case of swap/tdex/taxi txs.

it closes #198  

@tiero please review