### PR TITLE
fix webext-redux migration logic + add a check in "onStartup" listener

### DIFF
--- a/src/application/redux/reducers/index.ts
+++ b/src/application/redux/reducers/index.ts
@@ -45,8 +45,8 @@ function createLocalStorageConfig<S>(
     blacklist,
     migrate: (state: any) => {
       return Promise.resolve({
-        ...state,
         ...initialState,
+        ...state, // /!\ state should be merged **after** initialState !
       });
     },
   };

--- a/src/application/utils/transaction.ts
+++ b/src/application/utils/transaction.ts
@@ -98,7 +98,11 @@ export const isChange = (a: Address): boolean | null =>
  * @param tx txInterface
  * @param walletScripts the wallet's scripts i.e wallet scripts from wallet's addresses.
  */
-export function toDisplayTransaction(tx: TxInterface, walletScripts: string[], network: networks.Network): TxDisplayInterface {
+export function toDisplayTransaction(
+  tx: TxInterface,
+  walletScripts: string[],
+  network: networks.Network
+): TxDisplayInterface {
   const transfers = getTransfers(tx.vin, tx.vout, walletScripts, network);
   return {
     txId: tx.txid,

--- a/src/background-script.ts
+++ b/src/background-script.ts
@@ -47,8 +47,10 @@ browser.runtime.onInstalled.addListener(({ reason }) => {
 // /!\ FIX: prevent opening the onboarding page if the browser has been closed
 browser.runtime.onStartup.addListener(() => {
   (async () => {
-    // Everytime the browser starts up we need to set up the popup page
-    await browser.browserAction.setPopup({ popup: 'popup.html' });
+    if (marinaStore.getState().wallet.encryptedMnemonic !== '') {
+      // Everytime the browser starts up we need to set up the popup page
+      await browser.browserAction.setPopup({ popup: 'popup.html' });
+    }
   })().catch(console.error);
 });
 


### PR DESCRIPTION
This PR fixes the "Invalid password" problem after browser restart.

### What happened ? 
Redux persist uses migration schemes to handle reducer versionning. However, the current migration scheme was buggish. it overwrite the persisted state while we restart the browser (Rehydrate step in redux persist).

FIX:
1. merge `state` after `initialState` in migrator redux-persist.
2. before set the popup in `backgroundscript.ts`, we checks if there is an encrypted mnemonic persisted in browser storage. It lets, at least, to redirect to onboarding page if something goes wrong with mnemonic storage.

it closes #79 

@tiero please review