### PR TITLE
Extend `sendTransaction` and add `getFeeAssets`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ldk": "^0.3.9",
     "lodash.debounce": "^4.0.8",
     "lottie-web": "^5.7.8",
-    "marina-provider": "louisinger/marina-provider#new-send-transaction",
+    "marina-provider": "^1.4.0",
     "moment": "^2.29.1",
     "path-browserify": "^1.0.1",
     "postcss": "^7.0.35",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ldk": "^0.3.9",
     "lodash.debounce": "^4.0.8",
     "lottie-web": "^5.7.8",
-    "marina-provider": "^1.2.0",
+    "marina-provider": "louisinger/marina-provider#new-send-transaction",
     "moment": "^2.29.1",
     "path-browserify": "^1.0.1",
     "postcss": "^7.0.35",

--- a/src/application/backend.ts
+++ b/src/application/backend.ts
@@ -28,7 +28,8 @@ import {
   mnemonicWallet,
   taxiURL,
   toDisplayTransaction,
-  toStringOutpoint
+  toStringOutpoint,
+  lbtcAssetByNetwork
 } from './utils';
 import { signMessageWithMnemonic } from './utils/message';
 import {
@@ -67,6 +68,7 @@ import { getExplorerURLSelector } from './redux/selectors/app.selector';
 import { walletTransactions } from './redux/selectors/transaction.selector';
 import { balancesSelector } from './redux/selectors/balance.selector';
 import { Balance } from 'marina-provider';
+import { RecipientInterface } from 'ldk';
 
 const POPUP_HTML = 'popup.html';
 const UPDATE_ALARM = 'UPDATE_ALARM';
@@ -263,13 +265,20 @@ export default class Backend {
                 if (!(await this.isCurentSiteEnabled())) {
                   return handleError(id, new Error('User must authorize the current website'));
                 }
-                if (!params || params.length !== 3 || params.some((p) => p === null)) {
-                  return handleError(id, new Error('Missing params'));
-                }
-                const [recipientAddress, amountInSatoshis, assetHash]: string[] = params;
+
+                const [recipients, feeAssetHash] = params as [
+                  RecipientInterface[],
+                  string | undefined
+                ];
+
                 const hostname = await getCurrentUrl();
                 marinaStore.dispatch(
-                  setTxData(hostname, recipientAddress, amountInSatoshis, assetHash, network)
+                  setTxData(
+                    hostname,
+                    recipients,
+                    feeAssetHash ?? lbtcAssetByNetwork(network),
+                    network
+                  )
                 );
                 await showPopup(`connect/spend`);
 

--- a/src/application/backend.ts
+++ b/src/application/backend.ts
@@ -701,7 +701,7 @@ export function updateTxsHistory(): ThunkAction<void, RootReducerState, any, Any
       while (!it.done) {
         const tx = it.value;
         // Update all txsHistory state at each single new tx
-        const toAdd = toDisplayTransaction(tx, walletScripts);
+        const toAdd = toDisplayTransaction(tx, walletScripts, networks[app.network]);
         dispatch(addTx(toAdd, app.network));
         it = await txsGen.next();
       }

--- a/src/application/backend.ts
+++ b/src/application/backend.ts
@@ -18,7 +18,7 @@ import {
   fetchAndUnblindTxsGenerator,
   fetchAndUnblindUtxosGenerator,
   masterPubKeyRestorerFromState,
-  masterPubKeyRestorerFromEsplora,
+  masterPubKeyRestorerFromEsplora
 } from 'ldk';
 import Marina from './marina';
 import {
@@ -28,7 +28,7 @@ import {
   mnemonicWallet,
   taxiURL,
   toDisplayTransaction,
-  toStringOutpoint,
+  toStringOutpoint
 } from './utils';
 import { signMessageWithMnemonic } from './utils/message';
 import {
@@ -38,14 +38,14 @@ import {
   selectHostname,
   setMsg,
   setTx,
-  setTxData,
+  setTxData
 } from './redux/actions/connect';
 import {
   incrementAddressIndex,
   incrementChangeAddressIndex,
   setDeepRestorerError,
   setDeepRestorerIsLoading,
-  setWalletData,
+  setWalletData
 } from './redux/actions/wallet';
 import { Network } from '../domain/network';
 import { createAddress } from '../domain/address';
@@ -55,7 +55,7 @@ import { setTaxiAssets, updateTaxiAssets } from './redux/actions/taxi';
 import {
   masterPubKeySelector,
   restorerOptsSelector,
-  utxosSelector,
+  utxosSelector
 } from './redux/selectors/wallet.selector';
 import { addUtxo, deleteUtxo, updateUtxos } from './redux/actions/utxos';
 import { addAsset } from './redux/actions/asset';
@@ -316,8 +316,8 @@ export default class Backend {
                     {
                       address: recipient,
                       value: Number(amount),
-                      asset: assetHash,
-                    },
+                      asset: assetHash
+                    }
                   ],
                   greedyCoinSelector(),
                   (): string => changeAddress.confidentialAddress,
@@ -433,7 +433,7 @@ export default class Backend {
                 }
                 const coins = utxosSelector(marinaStore.getState());
                 return handleResponse(id, coins);
-              } catch (e) {
+              } catch (e: any) {
                 return handleError(id, e);
               }
 
@@ -475,11 +475,11 @@ export default class Backend {
         port.postMessage({ id, payload: { success: true, data } });
       };
 
-      const handleError = (id: string, e: Error) => {
+      const handleError = (id: string, e: any) => {
         console.error(e);
         port.postMessage({
           id,
-          payload: { success: false, error: e.message },
+          payload: { success: false, error: e.message }
         });
       };
     });
@@ -501,7 +501,7 @@ export function showPopup(path?: string): Promise<Windows.Window> {
     width: 360,
     focused: true,
     left: 100,
-    top: 100,
+    top: 100
   };
   return browser.windows.create(options as any);
 }
@@ -578,7 +578,7 @@ export function fetchAndUpdateUtxos(): ThunkAction<void, RootReducerState, any, 
 
       const currentOutpoints = Object.values(wallet.utxoMap).map(({ txid, vout }) => ({
         txid,
-        vout,
+        vout
       }));
 
       const skippedOutpoints: string[] = []; // for deleting
@@ -626,7 +626,7 @@ export function fetchAndUpdateUtxos(): ThunkAction<void, RootReducerState, any, 
         dispatch(deleteUtxo(outpoint.txid, outpoint.vout));
       }
     } catch (error) {
-      console.error(`fetchAndUpdateUtxos error: ${error.message}`);
+      console.error(`fetchAndUpdateUtxos error: ${error}`);
     }
   };
 }
@@ -750,7 +750,7 @@ export function startAlarmUpdater(): ThunkAction<void, RootReducerState, any, An
 
     browser.alarms.create(UPDATE_ALARM, {
       when: Date.now(),
-      periodInMinutes: 4,
+      periodInMinutes: 4
     });
   };
 }
@@ -777,7 +777,7 @@ export function deepRestorer(): ThunkAction<void, RootReducerState, any, AnyActi
         setWalletData({
           ...state.wallet,
           restorerOpts,
-          confidentialAddresses: addresses,
+          confidentialAddresses: addresses
         })
       );
 
@@ -786,7 +786,7 @@ export function deepRestorer(): ThunkAction<void, RootReducerState, any, AnyActi
       dispatch(fetchAndSetTaxiAssets());
 
       dispatch(setDeepRestorerError(undefined));
-    } catch (err) {
+    } catch (err: any) {
       dispatch(setDeepRestorerError(err.message || err));
     } finally {
       dispatch(setDeepRestorerIsLoading(false));

--- a/src/application/backend.ts
+++ b/src/application/backend.ts
@@ -454,6 +454,20 @@ export default class Backend {
                 return handleResponse(id, false);
               }
 
+            case Marina.prototype.getFeeAssets.name:
+              try {
+                if (!(await this.isCurentSiteEnabled())) {
+                  return handleError(id, new Error('User must authorize the current website'));
+                }
+
+                const taxiAssets = marinaStore.getState().taxi.taxiAssets;
+                const lbtcAsset = lbtcAssetByNetwork(getCurrentNetwork());
+
+                return handleResponse(id, [lbtcAsset, ...taxiAssets]);
+              } catch (e: any) {
+                return handleError(id, e);
+              }
+
             //
             default:
               return handleError(id, new Error('Method not implemented.'));

--- a/src/application/backend.ts
+++ b/src/application/backend.ts
@@ -267,15 +267,16 @@ export default class Backend {
                   string | undefined
                 ];
 
+                const lbtc = lbtcAssetByNetwork(network);
+                const feeAsset = feeAssetHash ? feeAssetHash : lbtc;
+                const taxiAssets = marinaStore.getState().taxi.taxiAssets;
+
+                if (![lbtc, ...taxiAssets].includes(feeAsset)) {
+                  return handleError(id, new Error(`${feeAsset} not supported as fee asset.`));
+                }
+
                 const hostname = await getCurrentUrl();
-                marinaStore.dispatch(
-                  setTxData(
-                    hostname,
-                    recipients,
-                    feeAssetHash ? feeAssetHash : lbtcAssetByNetwork(network),
-                    network
-                  )
-                );
+                marinaStore.dispatch(setTxData(hostname, recipients, feeAsset, network));
                 await showPopup(`connect/spend`);
 
                 const txhex = await this.waitForEvent(Marina.prototype.sendTransaction.name);

--- a/src/application/backend.ts
+++ b/src/application/backend.ts
@@ -613,7 +613,7 @@ export function fetchAndUpdateUtxos(): ThunkAction<void, RootReducerState, any, 
 
       if (utxoIterator.done) {
         console.info(`number of utxos fetched: ${utxoIterator.value.numberOfUtxos}`);
-        if (utxoIterator.value.errors) {
+        if (utxoIterator.value.errors.length > 0) {
           console.warn(
             `${utxoIterator.value.errors.length} errors occurs during utxos updater generator`
           );

--- a/src/application/marina.ts
+++ b/src/application/marina.ts
@@ -7,7 +7,7 @@ import {
   Transaction,
   Utxo,
   Balance,
-  MarinaEventType,
+  MarinaEventType
 } from 'marina-provider';
 import WindowProxy from './proxy';
 

--- a/src/application/marina.ts
+++ b/src/application/marina.ts
@@ -8,7 +8,7 @@ import {
   Utxo,
   Balance,
   MarinaEventType,
-  Recipient
+  Recipient,
 } from 'marina-provider';
 import WindowProxy from './proxy';
 

--- a/src/application/marina.ts
+++ b/src/application/marina.ts
@@ -7,7 +7,8 @@ import {
   Transaction,
   Utxo,
   Balance,
-  MarinaEventType
+  MarinaEventType,
+  Recipient
 } from 'marina-provider';
 import WindowProxy from './proxy';
 
@@ -48,12 +49,8 @@ export default class Marina extends WindowProxy implements MarinaProvider {
     return this.proxy(this.blindTransaction.name, [psetBase64]);
   }
 
-  sendTransaction(
-    recipientAddress: string,
-    amountInSatoshis: number,
-    assetHash: string
-  ): Promise<TransactionHex> {
-    return this.proxy(this.sendTransaction.name, [recipientAddress, amountInSatoshis, assetHash]);
+  sendTransaction(recipients: Recipient[], feeAssetHash?: string): Promise<TransactionHex> {
+    return this.proxy(this.sendTransaction.name, [recipients, feeAssetHash]);
   }
 
   signTransaction(psetBase64: PsetBase64): Promise<PsetBase64> {
@@ -86,5 +83,9 @@ export default class Marina extends WindowProxy implements MarinaProvider {
 
   isReady(): Promise<boolean> {
     return this.proxy(this.isReady.name, []);
+  }
+
+  getTaxiAssets(): Promise<string[]> {
+    return this.proxy(this.getTaxiAssets.name, []);
   }
 }

--- a/src/application/marina.ts
+++ b/src/application/marina.ts
@@ -85,7 +85,7 @@ export default class Marina extends WindowProxy implements MarinaProvider {
     return this.proxy(this.isReady.name, []);
   }
 
-  getTaxiAssets(): Promise<string[]> {
-    return this.proxy(this.getTaxiAssets.name, []);
+  getFeeAssets(): Promise<string[]> {
+    return this.proxy(this.getFeeAssets.name, []);
   }
 }

--- a/src/application/redux/actions/action-types.ts
+++ b/src/application/redux/actions/action-types.ts
@@ -42,7 +42,7 @@ export const ADD_ASSET = 'ADD_ASSET';
 // Connect data
 export const ENABLE_WEBSITE = 'ENABLE_WEBSITE';
 export const DISABLE_WEBSITE = 'DISABLE_WEBSITE';
-export const SET_TX = 'SET_TX';
+export const SET_TX_DATA = 'SET_TX_DATA';
 export const FLUSH_TX = 'FLUSH_TX';
 export const SET_MSG = 'SET_MSG';
 export const FLUSH_MSG = 'FLUSH_MSG';

--- a/src/application/redux/actions/connect.ts
+++ b/src/application/redux/actions/connect.ts
@@ -9,72 +9,73 @@ import {
   FLUSH_TX,
   SELECT_HOSTNAME,
   SET_MSG,
-  SET_TX,
+  SET_TX_DATA
 } from './action-types';
+
+import { RecipientInterface } from 'ldk';
 
 export function enableWebsite(hostname: string, network: Network): AnyAction {
   return {
     type: ENABLE_WEBSITE,
-    payload: { hostname, network },
+    payload: { hostname, network }
   };
 }
 
 export function disableWebsite(hostname: string, network: Network): AnyAction {
   return {
     type: DISABLE_WEBSITE,
-    payload: { hostname, network },
+    payload: { hostname, network }
   };
 }
 
 export function setMsg(hostname: string, message: string): AnyAction {
   return {
     type: SET_MSG,
-    payload: { hostname, message },
+    payload: { hostname, message }
   };
 }
 
 export function flushMsg(): AnyAction {
   return {
-    type: FLUSH_MSG,
+    type: FLUSH_MSG
   };
 }
 
 export function flushTx(): AnyAction {
   return {
-    type: FLUSH_TX,
+    type: FLUSH_TX
   };
 }
 
 export function setTx(hostname: string, pset: string): AnyAction {
   return {
-    type: SET_TX,
-    payload: { hostname, pset } as ConnectData['tx'],
+    type: SET_TX_DATA,
+    payload: { hostname, pset } as ConnectData['tx']
   };
 }
 
 export function setTxData(
   hostname: string,
-  recipient: string,
-  amount: string,
-  assetHash: string,
+  recipients: RecipientInterface[],
+  feeAssetHash: string,
   network: Network
 ): AnyAction {
   return {
-    type: SET_TX,
-    payload: { hostname, recipient, amount, assetHash, network } as ConnectData['tx'],
+    type: SET_TX_DATA,
+    payload: { hostname, recipients, feeAssetHash, network } as ConnectData['tx']
   };
 }
 
 export function selectHostname(hostname: string, network: Network): AnyAction {
   return {
     type: SELECT_HOSTNAME,
-    payload: { hostname, network },
+    payload: { hostname, network }
   };
 }
 
 export function flushSelectedHostname(network: Network): AnyAction {
   return {
     type: FLUSH_SELECTED_HOSTNAME,
-    payload: { network },
+    payload: { network }
   };
 }

--- a/src/application/redux/actions/connect.ts
+++ b/src/application/redux/actions/connect.ts
@@ -9,7 +9,7 @@ import {
   FLUSH_TX,
   SELECT_HOSTNAME,
   SET_MSG,
-  SET_TX_DATA
+  SET_TX_DATA,
 } from './action-types';
 
 import { RecipientInterface } from 'ldk';
@@ -17,40 +17,40 @@ import { RecipientInterface } from 'ldk';
 export function enableWebsite(hostname: string, network: Network): AnyAction {
   return {
     type: ENABLE_WEBSITE,
-    payload: { hostname, network }
+    payload: { hostname, network },
   };
 }
 
 export function disableWebsite(hostname: string, network: Network): AnyAction {
   return {
     type: DISABLE_WEBSITE,
-    payload: { hostname, network }
+    payload: { hostname, network },
   };
 }
 
 export function setMsg(hostname: string, message: string): AnyAction {
   return {
     type: SET_MSG,
-    payload: { hostname, message }
+    payload: { hostname, message },
   };
 }
 
 export function flushMsg(): AnyAction {
   return {
-    type: FLUSH_MSG
+    type: FLUSH_MSG,
   };
 }
 
 export function flushTx(): AnyAction {
   return {
-    type: FLUSH_TX
+    type: FLUSH_TX,
   };
 }
 
 export function setTx(hostname: string, pset: string): AnyAction {
   return {
     type: SET_TX_DATA,
-    payload: { hostname, pset } as ConnectData['tx']
+    payload: { hostname, pset } as ConnectData['tx'],
   };
 }
 
@@ -62,20 +62,20 @@ export function setTxData(
 ): AnyAction {
   return {
     type: SET_TX_DATA,
-    payload: { hostname, recipients, feeAssetHash, network } as ConnectData['tx']
+    payload: { hostname, recipients, feeAssetHash, network } as ConnectData['tx'],
   };
 }
 
 export function selectHostname(hostname: string, network: Network): AnyAction {
   return {
     type: SELECT_HOSTNAME,
-    payload: { hostname, network }
+    payload: { hostname, network },
   };
 }
 
 export function flushSelectedHostname(network: Network): AnyAction {
   return {
     type: FLUSH_SELECTED_HOSTNAME,
-    payload: { network }
+    payload: { network },
   };
 }

--- a/src/application/redux/reducers/connect-data-reducer.ts
+++ b/src/application/redux/reducers/connect-data-reducer.ts
@@ -15,8 +15,8 @@ export function connectDataReducer(
         ...state,
         enabledSites: {
           ...state.enabledSites,
-          [payload.network]: [...state.enabledSites[payload.network as Network], payload.hostname],
-        },
+          [payload.network]: [...state.enabledSites[payload.network as Network], payload.hostname]
+        }
       };
     }
 
@@ -27,43 +27,43 @@ export function connectDataReducer(
           ...state.enabledSites,
           [payload.network]: state.enabledSites[payload.network as Network].filter(
             (v) => v !== payload.hostname
-          ),
-        },
+          )
+        }
       };
     }
 
     case ACTION_TYPES.SET_MSG: {
       return {
         ...state,
-        msg: { hostname: payload.hostname, message: payload.message },
+        msg: { hostname: payload.hostname, message: payload.message }
       };
     }
 
     case ACTION_TYPES.FLUSH_MSG: {
       return {
         ...state,
-        msg: undefined,
+        msg: undefined
       };
     }
 
-    case ACTION_TYPES.SET_TX: {
+    case ACTION_TYPES.SET_TX_DATA: {
       return {
         ...state,
-        tx: payload,
+        tx: payload
       };
     }
 
     case ACTION_TYPES.SELECT_HOSTNAME: {
       return {
         ...state,
-        hostnameSelected: payload.hostname,
+        hostnameSelected: payload.hostname
       };
     }
 
     case ACTION_TYPES.FLUSH_SELECTED_HOSTNAME: {
       return {
         ...state,
-        hostnameSelected: '',
+        hostnameSelected: ''
       };
     }
 

--- a/src/application/redux/reducers/connect-data-reducer.ts
+++ b/src/application/redux/reducers/connect-data-reducer.ts
@@ -15,8 +15,8 @@ export function connectDataReducer(
         ...state,
         enabledSites: {
           ...state.enabledSites,
-          [payload.network]: [...state.enabledSites[payload.network as Network], payload.hostname]
-        }
+          [payload.network]: [...state.enabledSites[payload.network as Network], payload.hostname],
+        },
       };
     }
 
@@ -27,43 +27,43 @@ export function connectDataReducer(
           ...state.enabledSites,
           [payload.network]: state.enabledSites[payload.network as Network].filter(
             (v) => v !== payload.hostname
-          )
-        }
+          ),
+        },
       };
     }
 
     case ACTION_TYPES.SET_MSG: {
       return {
         ...state,
-        msg: { hostname: payload.hostname, message: payload.message }
+        msg: { hostname: payload.hostname, message: payload.message },
       };
     }
 
     case ACTION_TYPES.FLUSH_MSG: {
       return {
         ...state,
-        msg: undefined
+        msg: undefined,
       };
     }
 
     case ACTION_TYPES.SET_TX_DATA: {
       return {
         ...state,
-        tx: payload
+        tx: payload,
       };
     }
 
     case ACTION_TYPES.SELECT_HOSTNAME: {
       return {
         ...state,
-        hostnameSelected: payload.hostname
+        hostnameSelected: payload.hostname,
       };
     }
 
     case ACTION_TYPES.FLUSH_SELECTED_HOSTNAME: {
       return {
         ...state,
-        hostnameSelected: ''
+        hostnameSelected: '',
       };
     }
 

--- a/src/application/utils/transaction.ts
+++ b/src/application/utils/transaction.ts
@@ -1,4 +1,3 @@
-import { liquid } from './../../../test/fixtures/network';
 import {
   address as addrLDK,
   addToTx,
@@ -16,7 +15,7 @@ import {
   UnblindedOutputInterface,
   UtxoInterface,
 } from 'ldk';
-import { confidential } from 'liquidjs-lib';
+import { confidential, networks } from 'liquidjs-lib';
 import { blindingKeyFromAddress, isConfidentialAddress } from './address';
 import { Transfer, TxDisplayInterface, TxStatusEnum, TxTypeEnum } from '../../domain/transaction';
 import { Address } from '../../domain/address';
@@ -99,8 +98,8 @@ export const isChange = (a: Address): boolean | null =>
  * @param tx txInterface
  * @param walletScripts the wallet's scripts i.e wallet scripts from wallet's addresses.
  */
-export function toDisplayTransaction(tx: TxInterface, walletScripts: string[]): TxDisplayInterface {
-  const transfers = getTransfers(tx.vin, tx.vout, walletScripts);
+export function toDisplayTransaction(tx: TxInterface, walletScripts: string[], network: networks.Network): TxDisplayInterface {
+  const transfers = getTransfers(tx.vin, tx.vout, walletScripts, network);
   return {
     txId: tx.txid,
     blockTimeMs: tx.status.blockTime ? tx.status.blockTime * 1000 : undefined,
@@ -153,7 +152,8 @@ function txTypeFromTransfer(transfers: Transfer[]) {
 function getTransfers(
   vin: Array<InputInterface>,
   vout: Array<BlindedOutputInterface | UnblindedOutputInterface>,
-  walletScripts: string[]
+  walletScripts: string[],
+  network: networks.Network
 ): Transfer[] {
   const transfers: Transfer[] = [];
 
@@ -178,7 +178,7 @@ function getTransfers(
   }
 
   let feeAmount = 0;
-  let feeAsset = liquid.assetHash;
+  let feeAsset = network.assetHash;
 
   for (const output of vout) {
     if (output.script === '') {

--- a/src/application/utils/transaction.ts
+++ b/src/application/utils/transaction.ts
@@ -6,20 +6,25 @@ import {
   CoinSelector,
   decodePset,
   getUnblindURLFromTx,
+  greedyCoinSelector,
   InputInterface,
   isBlindedOutputInterface,
+  Mnemonic,
   psetToUnsignedTx,
   RecipientInterface,
-  StateRestorerOpts,
   TxInterface,
   UnblindedOutputInterface,
   UtxoInterface,
+  walletFromCoins,
 } from 'ldk';
 import { confidential, networks } from 'liquidjs-lib';
 import { blindingKeyFromAddress, isConfidentialAddress } from './address';
 import { Transfer, TxDisplayInterface, TxStatusEnum, TxTypeEnum } from '../../domain/transaction';
-import { Address } from '../../domain/address';
-import { mnemonicWallet } from './restorer';
+import { Topup } from 'taxi-protobuf/generated/js/taxi_pb';
+import { lbtcAssetByNetwork } from './network';
+import { Network } from '../../domain/network';
+import { fetchTopupFromTaxi } from './taxi';
+import { taxiURL } from './constants';
 
 function outPubKeysMap(pset: string, outputAddresses: string[]): Map<number, string> {
   const outPubkeys: Map<number, string> = new Map();
@@ -36,23 +41,25 @@ function outPubKeysMap(pset: string, outputAddresses: string[]): Map<number, str
   return outPubkeys;
 }
 
+/**
+ * Take an unsigned pset, blind it according to recipientAddresses and sign the pset using the mnemonic.
+ * @param mnemonic Identity using to sign the tx. should be restored.
+ * @param psetBase64 the unsign tx.
+ * @param recipientAddresses a list of known recipients addresses (non wallet output addresses).
+ */
 export async function blindAndSignPset(
-  mnemonic: string,
-  restorerOpts: StateRestorerOpts,
-  chain: string,
+  mnemonic: Mnemonic,
   psetBase64: string,
   recipientAddresses: string[]
 ): Promise<string> {
-  const mnemo = await mnemonicWallet(mnemonic, restorerOpts, chain);
-
-  const outputAddresses = (await mnemo.getAddresses()).map((a) => a.confidentialAddress);
+  const outputAddresses = (await mnemonic.getAddresses()).map((a) => a.confidentialAddress);
 
   const outputPubKeys = outPubKeysMap(psetBase64, outputAddresses.concat(recipientAddresses));
   const outputsToBlind = Array.from(outputPubKeys.keys());
 
-  const blindedPset: string = await mnemo.blindPset(psetBase64, outputsToBlind, outputPubKeys);
+  const blindedPset: string = await mnemonic.blindPset(psetBase64, outputsToBlind, outputPubKeys);
 
-  const signedPset: string = await mnemo.signPset(blindedPset);
+  const signedPset: string = await mnemonic.signPset(blindedPset);
 
   const ptx = decodePset(signedPset);
   if (!ptx.validateSignaturesOfAllInputs()) {
@@ -61,37 +68,86 @@ export async function blindAndSignPset(
   return ptx.finalizeAllInputs().extractTransaction().toHex();
 }
 
-export function fillTaxiTx(
-  psetBase64: string,
-  unspents: UtxoInterface[],
-  receipients: RecipientInterface[],
-  taxiPayout: RecipientInterface,
-  coinSelector: CoinSelector,
-  changeAddressGetter: ChangeAddressFromAssetGetter
-): string {
-  const { selectedUtxos, changeOutputs } = coinSelector(
-    unspents,
-    receipients.concat(taxiPayout),
-    changeAddressGetter
-  );
-  return addToTx(psetBase64, selectedUtxos, receipients.concat(changeOutputs));
-}
-
 function outputIndexFromAddress(tx: string, addressToFind: string): number {
   const utx = psetToUnsignedTx(tx);
   const receipientScript = addrLDK.toOutputScript(addressToFind);
   return utx.outs.findIndex((out) => out.script.equals(receipientScript));
 }
 
+/**
+ * Create tx from a Topup object.
+ * @param taxiTopup the topup describing the taxi response.
+ * @param unspents a list of utxos used to fund the tx.
+ * @param recipients a list of output to send.
+ * @param coinSelector the way used to coin select the unspents.
+ * @param changeAddressGetter define the way we get change addresses (if needed).
+ */
+export function createTaxiTxFromTopup(
+  taxiTopup: Topup.AsObject,
+  unspents: UtxoInterface[],
+  recipients: RecipientInterface[],
+  coinSelector: CoinSelector,
+  changeAddressGetter: ChangeAddressFromAssetGetter
+): string {
+  const { selectedUtxos, changeOutputs } = coinSelector(
+    unspents,
+    recipients.concat({
+      value: taxiTopup.assetAmount,
+      asset: taxiTopup.assetHash,
+      address: '', // address is not useful for coinSelector
+    }),
+    changeAddressGetter
+  );
+  return addToTx(taxiTopup.partial, selectedUtxos, recipients.concat(changeOutputs));
+}
+
+/**
+ * Create an unsigned tx from utxos set and list of recipients.
+ * @param recipients will create the outputs.
+ * @param unspents will be selected for the inputs.
+ * @param feeAssetHash if !== L-BTC: we'll request taxi to pay the fees.
+ * @param changeAddressGetter the way we fetch change addresses.
+ */
+export async function createSendPset(
+  recipients: RecipientInterface[],
+  unspents: UtxoInterface[],
+  feeAssetHash: string,
+  changeAddressGetter: ChangeAddressFromAssetGetter,
+  network: Network
+): Promise<string> {
+  if (feeAssetHash === lbtcAssetByNetwork(network)) {
+    const txBuilder = walletFromCoins(unspents, network);
+    return txBuilder.buildTx(
+      txBuilder.createTx(),
+      recipients,
+      greedyCoinSelector(),
+      changeAddressGetter,
+      true
+    );
+  }
+
+  const topup = (await fetchTopupFromTaxi(taxiURL[network], feeAssetHash)).topup;
+  if (!topup) throw new Error('something went wrong with taxi');
+
+  return createTaxiTxFromTopup(
+    topup,
+    unspents,
+    recipients,
+    greedyCoinSelector(),
+    changeAddressGetter
+  );
+}
+
+/**
+ * extract the fee amount (in satoshi) from an unsigned transaction.
+ * @param tx base64 encoded string.
+ */
 export const feeAmountFromTx = (tx: string): number => {
   const utx = psetToUnsignedTx(tx);
   const feeOutIndex = utx.outs.findIndex((out) => out.script.length === 0);
   const feeOut = utx.outs[feeOutIndex];
   return confidential.confidentialValueToSatoshi(feeOut.value);
 };
-
-export const isChange = (a: Address): boolean | null =>
-  a?.derivationPath ? a.derivationPath?.split('/')[4] === '1' : null;
 
 /**
  * Convert a TxInterface to DisplayInterface

--- a/src/domain/app.ts
+++ b/src/domain/app.ts
@@ -31,6 +31,6 @@ export const NigiriDefaultExplorerURLs: ExplorerURLs = {
 
 export const MempoolExplorerURLs: ExplorerURLs = {
   type: 'Mempool',
-  electrsURL: 'https://mempool.space/liquid',
-  esploraURL: 'https://mempool.space/liquid/api',
+  electrsURL: 'https://liquid.network',
+  esploraURL: 'https://liquid.network/api',
 };

--- a/src/domain/connect.ts
+++ b/src/domain/connect.ts
@@ -1,13 +1,13 @@
 import { Network } from './network';
+import { RecipientInterface } from 'ldk';
 
 export type ConnectData = {
   enabledSites: Record<Network, string[]>;
   hostnameSelected: string;
   tx?: {
-    amount?: string;
-    assetHash?: string;
+    recipients?: RecipientInterface[];
+    feeAssetHash?: string;
     hostname?: string;
-    recipient?: string;
     pset?: string;
   };
   msg?: {
@@ -20,8 +20,8 @@ export function newEmptyConnectData(): ConnectData {
   return {
     enabledSites: {
       liquid: [],
-      regtest: [],
+      regtest: []
     },
-    hostnameSelected: '',
+    hostnameSelected: ''
   };
 }

--- a/src/domain/connect.ts
+++ b/src/domain/connect.ts
@@ -20,8 +20,8 @@ export function newEmptyConnectData(): ConnectData {
   return {
     enabledSites: {
       liquid: [],
-      regtest: []
+      regtest: [],
     },
-    hostnameSelected: ''
+    hostnameSelected: '',
   };
 }

--- a/src/presentation/connect/spend.tsx
+++ b/src/presentation/connect/spend.tsx
@@ -130,7 +130,7 @@ const ConnectSpend: React.FC<WithConnectDataProps> = ({ connectData }) => {
             onClick={handleUnlockModalOpen}
             textBase={true}
           >
-            Retry
+            Unlock
           </Button>
         </div>
       )}

--- a/src/presentation/connect/spend.tsx
+++ b/src/presentation/connect/spend.tsx
@@ -8,7 +8,7 @@ import WindowProxy from '../../application/proxy';
 import { useSelector } from 'react-redux';
 import {
   connectWithConnectData,
-  WithConnectDataProps
+  WithConnectDataProps,
 } from '../../application/redux/containers/with-connect-data.container';
 import { RootReducerState } from '../../domain/common';
 import type { RecipientInterface } from 'ldk';

--- a/src/presentation/connect/spend.tsx
+++ b/src/presentation/connect/spend.tsx
@@ -8,21 +8,20 @@ import WindowProxy from '../../application/proxy';
 import { useSelector } from 'react-redux';
 import {
   connectWithConnectData,
-  WithConnectDataProps,
+  WithConnectDataProps
 } from '../../application/redux/containers/with-connect-data.container';
 import { RootReducerState } from '../../domain/common';
+import type { RecipientInterface } from 'ldk';
 
 const ConnectSpend: React.FC<WithConnectDataProps> = ({ connectData }) => {
   const assets = useSelector((state: RootReducerState) => state.assets);
+  const getTicker = (assetHash: string) => assets[assetHash]?.ticker ?? 'Unknown';
 
   const [isModalUnlockOpen, showUnlockModal] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
 
   const windowProxy = new WindowProxy();
 
-  const assetTicker = connectData.tx?.assetHash
-    ? assets[connectData.tx.assetHash]?.ticker
-    : 'Unknown';
   const handleModalUnlockClose = () => showUnlockModal(false);
   const handleUnlockModalOpen = () => showUnlockModal(true);
 
@@ -64,17 +63,21 @@ const ConnectSpend: React.FC<WithConnectDataProps> = ({ connectData }) => {
 
           <p className="mt-4 text-base font-medium">Requests you to spend</p>
 
-          <div className="container flex justify-between mt-16">
-            <span className="text-lg font-medium">{connectData.tx?.amount}</span>
-            <span className="text-lg font-medium">{assetTicker}</span>
-          </div>
+          {connectData.tx?.recipients?.map((recipient: RecipientInterface) => (
+            <>
+              <div className="container flex justify-between mt-16">
+                <span className="text-lg font-medium">{recipient.value}</span>
+                <span className="text-lg font-medium">{getTicker(recipient.asset)}</span>
+              </div>
 
-          <div className="container flex items-baseline justify-between mt-4">
-            <span className="mr-2 text-lg font-medium">To: </span>
-            <span className="font-small text-sm break-all">
-              {formatAddress(connectData.tx?.recipient ?? '')}
-            </span>
-          </div>
+              <div className="container flex items-baseline justify-between mt-4">
+                <span className="mr-2 text-lg font-medium">To: </span>
+                <span className="font-small text-sm break-all">
+                  {formatAddress(recipient.address)}
+                </span>
+              </div>
+            </>
+          ))}
 
           <div className="bottom-24 container absolute right-0 flex justify-between">
             <Button isOutline={true} onClick={handleReject} textBase={true}>

--- a/src/presentation/connect/spend.tsx
+++ b/src/presentation/connect/spend.tsx
@@ -86,7 +86,7 @@ const ConnectSpend: React.FC<WithConnectDataProps> = ({ connectData }) => {
 
   return (
     <ShellConnectPopup
-      className="h-popupContent container pb-20 mx-auto text-center bg-bottom bg-no-repeat"
+      className="h-popupContent max-w-sm pb-20 text-center bg-bottom bg-no-repeat"
       currentPage="Spend"
     >
       {error.length === 0 ? (
@@ -121,18 +121,18 @@ const ConnectSpend: React.FC<WithConnectDataProps> = ({ connectData }) => {
           </div>
         </>
       ) : (
-        <>
+        <div className="flex flex-col justify-center p-2 align-middle">
           <h1 className="mt-8 text-lg font-medium">Oops, Something went wrong...</h1>
-          <p className="font-small mt-4 text-sm">{error}</p>
+          <span className="max-w-xs mr-2 font-light">{error}</span>
           <img className="mx-auto my-10" src="/assets/images/cross.svg" alt="error" />
           <Button
             className="w-36 container mx-auto mt-10"
             onClick={handleUnlockModalOpen}
             textBase={true}
           >
-            Unlock
+            Retry
           </Button>
-        </>
+        </div>
       )}
       <ModalUnlock
         isModalUnlockOpen={isModalUnlockOpen}

--- a/src/presentation/wallet/send/choose-fee.tsx
+++ b/src/presentation/wallet/send/choose-fee.tsx
@@ -6,7 +6,7 @@ import {
   MasterPublicKey,
   RecipientInterface,
   StateRestorerOpts,
-  walletFromCoins
+  walletFromCoins,
 } from 'ldk';
 import Balance from '../../components/balance';
 import Button from '../../components/button';
@@ -16,11 +16,11 @@ import {
   feeAmountFromTx,
   feeLevelToSatsPerByte,
   fetchTopupFromTaxi,
-  fillTaxiTx,
+  createTaxiTxFromTopup,
   imgPathMapMainnet,
   imgPathMapRegtest,
   lbtcAssetByNetwork,
-  taxiURL
+  taxiURL,
 } from '../../../application/utils';
 import { formatDecimalAmount, fromSatoshi, fromSatoshiStr } from '../../utils';
 import useLottieLoader from '../../hooks/use-lottie-loader';
@@ -31,7 +31,7 @@ import { BalancesByAsset } from '../../../application/redux/selectors/balance.se
 import {
   setFeeAssetAndAmount,
   setFeeChangeAddress,
-  setPset
+  setPset,
 } from '../../../application/redux/actions/transaction';
 import { Network } from '../../../domain/network';
 import { ProxyStoreDispatch } from '../../../application/redux/proxyStore';
@@ -66,7 +66,7 @@ const ChooseFeeView: React.FC<ChooseFeeProps> = ({
   taxiAssets,
   lbtcAssetHash,
   masterPubKey,
-  restorerOpts
+  restorerOpts,
 }) => {
   const history = useHistory();
   const dispatch = useDispatch<ProxyStoreDispatch>();
@@ -97,8 +97,8 @@ const ChooseFeeView: React.FC<ChooseFeeProps> = ({
         {
           asset: sendAsset,
           value: sendAmount,
-          address: sendAddress.value
-        }
+          address: sendAddress.value,
+        },
       ];
 
       if (feeCurrency === lbtcAssetByNetwork(network)) {
@@ -147,12 +147,6 @@ const ChooseFeeView: React.FC<ChooseFeeProps> = ({
       throw new Error('Taxi topup is undefined');
     }
 
-    const taxiPayout: RecipientInterface = {
-      value: taxiTopup.assetAmount,
-      asset: taxiTopup.assetHash,
-      address: ''
-    };
-
     let nextChangeAddr = feeChange;
     if (!nextChangeAddr) {
       const restored = await masterPubKeyRestorerFromState(masterPubKey)(restorerOpts);
@@ -168,11 +162,10 @@ const ChooseFeeView: React.FC<ChooseFeeProps> = ({
       return nextChangeAddr?.value;
     };
 
-    const tx: string = fillTaxiTx(
-      taxiTopup.partial,
+    const tx: string = createTaxiTxFromTopup(
+      taxiTopup,
       Object.values(wallet.utxoMap),
       recipients,
-      taxiPayout,
       greedyCoinSelector(),
       changeGetter
     );
@@ -196,18 +189,18 @@ const ChooseFeeView: React.FC<ChooseFeeProps> = ({
 
       await Promise.all([
         dispatch(setPset(unsignedPendingTx)),
-        dispatch(setFeeAssetAndAmount(feeCurrency, feeAmount))
+        dispatch(setFeeAssetAndAmount(feeCurrency, feeAmount)),
       ]);
 
       if (feeChange) {
         await Promise.all([
           dispatch(setFeeChangeAddress(feeChange)),
-          dispatch(incrementChangeAddressIndex())
+          dispatch(incrementChangeAddressIndex()),
         ]);
       }
 
       history.push({
-        pathname: SEND_CONFIRMATION_ROUTE
+        pathname: SEND_CONFIRMATION_ROUTE,
       });
     } catch (error: any) {
       console.error(error);

--- a/src/presentation/wallet/send/choose-fee.tsx
+++ b/src/presentation/wallet/send/choose-fee.tsx
@@ -6,7 +6,7 @@ import {
   MasterPublicKey,
   RecipientInterface,
   StateRestorerOpts,
-  walletFromCoins,
+  walletFromCoins
 } from 'ldk';
 import Balance from '../../components/balance';
 import Button from '../../components/button';
@@ -20,7 +20,7 @@ import {
   imgPathMapMainnet,
   imgPathMapRegtest,
   lbtcAssetByNetwork,
-  taxiURL,
+  taxiURL
 } from '../../../application/utils';
 import { formatDecimalAmount, fromSatoshi, fromSatoshiStr } from '../../utils';
 import useLottieLoader from '../../hooks/use-lottie-loader';
@@ -31,7 +31,7 @@ import { BalancesByAsset } from '../../../application/redux/selectors/balance.se
 import {
   setFeeAssetAndAmount,
   setFeeChangeAddress,
-  setPset,
+  setPset
 } from '../../../application/redux/actions/transaction';
 import { Network } from '../../../domain/network';
 import { ProxyStoreDispatch } from '../../../application/redux/proxyStore';
@@ -66,7 +66,7 @@ const ChooseFeeView: React.FC<ChooseFeeProps> = ({
   taxiAssets,
   lbtcAssetHash,
   masterPubKey,
-  restorerOpts,
+  restorerOpts
 }) => {
   const history = useHistory();
   const dispatch = useDispatch<ProxyStoreDispatch>();
@@ -97,8 +97,8 @@ const ChooseFeeView: React.FC<ChooseFeeProps> = ({
         {
           asset: sendAsset,
           value: sendAmount,
-          address: sendAddress.value,
-        },
+          address: sendAddress.value
+        }
       ];
 
       if (feeCurrency === lbtcAssetByNetwork(network)) {
@@ -150,7 +150,7 @@ const ChooseFeeView: React.FC<ChooseFeeProps> = ({
     const taxiPayout: RecipientInterface = {
       value: taxiTopup.assetAmount,
       asset: taxiTopup.assetHash,
-      address: '',
+      address: ''
     };
 
     let nextChangeAddr = feeChange;
@@ -196,22 +196,22 @@ const ChooseFeeView: React.FC<ChooseFeeProps> = ({
 
       await Promise.all([
         dispatch(setPset(unsignedPendingTx)),
-        dispatch(setFeeAssetAndAmount(feeCurrency, feeAmount)),
+        dispatch(setFeeAssetAndAmount(feeCurrency, feeAmount))
       ]);
 
       if (feeChange) {
         await Promise.all([
           dispatch(setFeeChangeAddress(feeChange)),
-          dispatch(incrementChangeAddressIndex()),
+          dispatch(incrementChangeAddressIndex())
         ]);
       }
 
       history.push({
-        pathname: SEND_CONFIRMATION_ROUTE,
+        pathname: SEND_CONFIRMATION_ROUTE
       });
-    } catch (error) {
+    } catch (error: any) {
       console.error(error);
-      setErrorMessage(error.message);
+      setErrorMessage(error.message || error);
     } finally {
       setLoading(false);
     }

--- a/src/presentation/wallet/send/end-of-flow.tsx
+++ b/src/presentation/wallet/send/end-of-flow.tsx
@@ -3,7 +3,7 @@ import { useHistory } from 'react-router';
 import Button from '../../components/button';
 import ModalUnlock from '../../components/modal-unlock';
 import ShellPopUp from '../../components/shell-popup';
-import { blindAndSignPset, broadcastTx, decrypt } from '../../../application/utils';
+import { blindAndSignPset, broadcastTx, decrypt, mnemonicWallet } from '../../../application/utils';
 import { SEND_PAYMENT_ERROR_ROUTE, SEND_PAYMENT_SUCCESS_ROUTE } from '../../routes/constants';
 import { debounce } from 'lodash';
 import { IWallet } from '../../../domain/wallet';
@@ -46,19 +46,20 @@ const EndOfFlow: React.FC<EndOfFlowProps> = ({
 
       const mnemonic = decrypt(wallet.encryptedMnemonic, pass);
 
-      tx = await blindAndSignPset(mnemonic, restorerOpts, network, pset, [recipientAddress]);
+      const mnemo = await mnemonicWallet(mnemonic, restorerOpts, network);
+      tx = await blindAndSignPset(mnemo, pset, [recipientAddress]);
 
       const txid = await broadcastTx(explorerURL, tx);
       history.push({
         pathname: SEND_PAYMENT_SUCCESS_ROUTE,
         state: { txid },
       });
-    } catch (error) {
+    } catch (error: any) {
       return history.push({
         pathname: SEND_PAYMENT_ERROR_ROUTE,
         state: {
           tx: tx,
-          error: error.message,
+          error: error.message ?? error,
         },
       });
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6330,10 +6330,14 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marina-provider@^1.0.0, marina-provider@^1.2.0:
+marina-provider@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/marina-provider/-/marina-provider-1.3.0.tgz#ee26222816570e5649457c5eb6f3078433af5cd8"
   integrity sha512-J00cMcynnNwLut8GdbLNHSHR7jKUGcaiJfExgomIDbIMXJD/nZZQlxg8/zzPsAnujMx/aAEqqfEj+h4PIohp9g==
+
+marina-provider@louisinger/marina-provider#new-send-transaction:
+  version "1.3.0"
+  resolved "https://codeload.github.com/louisinger/marina-provider/tar.gz/c547530cd62d75351ae5e3f561c4c3023539c7f4"
 
 marky@^1.2.0:
   version "1.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6337,7 +6337,7 @@ marina-provider@^1.0.0:
 
 marina-provider@louisinger/marina-provider#new-send-transaction:
   version "1.3.0"
-  resolved "https://codeload.github.com/louisinger/marina-provider/tar.gz/c547530cd62d75351ae5e3f561c4c3023539c7f4"
+  resolved "https://codeload.github.com/louisinger/marina-provider/tar.gz/06542f44bf6d803af8d1e9b1f235b936af075d47"
 
 marky@^1.2.0:
   version "1.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6335,9 +6335,10 @@ marina-provider@^1.0.0:
   resolved "https://registry.yarnpkg.com/marina-provider/-/marina-provider-1.3.0.tgz#ee26222816570e5649457c5eb6f3078433af5cd8"
   integrity sha512-J00cMcynnNwLut8GdbLNHSHR7jKUGcaiJfExgomIDbIMXJD/nZZQlxg8/zzPsAnujMx/aAEqqfEj+h4PIohp9g==
 
-marina-provider@louisinger/marina-provider#new-send-transaction:
-  version "1.3.0"
-  resolved "https://codeload.github.com/louisinger/marina-provider/tar.gz/06542f44bf6d803af8d1e9b1f235b936af075d47"
+marina-provider@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/marina-provider/-/marina-provider-1.4.0.tgz#ae502bc641a251888270dd393cc06739d5c1e459"
+  integrity sha512-S2kFaFc0GdQ/EneW+dwAv+VP8Tvxsk1qhdM/PTG/I5kC9yJbPB5knv0bqlh/bkIuK7nrmLP9gV1mBddbIRtBcA==
 
 marky@^1.2.0:
   version "1.2.2"


### PR DESCRIPTION
This PR implements the new changes introduced by marina-provider 1.4.0.

* `sendTransaction` now accepts a list of recipients, and an optional feeAssetHash parameter.
* if the feeAssetHash is not LBTC, we'll use liquid.taxi to craft a taxi tx.
* `getFeeAssets` returns all the asset accepted as fee (taxiAssets + L-BTC).
* rework and cleaning of `utils/transaction.ts`.

it closes #214 

@tiero please review