### PR TITLE
Add `ReceiveSelectAsset` page before the address generation

### DIFF
--- a/src/application/redux/containers/receive-select-asset.container.ts
+++ b/src/application/redux/containers/receive-select-asset.container.ts
@@ -1,19 +1,20 @@
 import { connect } from 'react-redux';
 import { assetGetterFromIAssets } from '../../../domain/assets';
 import { RootReducerState } from '../../../domain/common';
-import SelectAssetView, { SelectAssetProps } from '../../../presentation/wallet/send/select-asset';
+import ReceiveSelectAssetView, {
+  ReceiveSelectAssetProps,
+} from '../../../presentation/wallet/receive/receive-select-asset';
 import { balancesSelector } from '../selectors/balance.selector';
 
-const mapStateToProps = (state: RootReducerState): SelectAssetProps => {
+const mapStateToProps = (state: RootReducerState): ReceiveSelectAssetProps => {
   const balances = balancesSelector(state);
   const getAsset = assetGetterFromIAssets(state.assets);
   return {
     network: state.app.network,
-    balanceAssets: Object.keys(balances).map(getAsset),
-    balances,
+    assets: Object.keys(balances).map(getAsset),
   };
 };
 
-const Home = connect(mapStateToProps)(SelectAssetView);
+const ReceiveSelectAsset = connect(mapStateToProps)(ReceiveSelectAssetView);
 
-export default Home;
+export default ReceiveSelectAsset;

--- a/src/application/redux/containers/send-select-asset.container.ts
+++ b/src/application/redux/containers/send-select-asset.container.ts
@@ -1,0 +1,21 @@
+import { connect } from 'react-redux';
+import { assetGetterFromIAssets } from '../../../domain/assets';
+import { RootReducerState } from '../../../domain/common';
+import SendSelectAssetView, {
+  SendSelectAssetProps,
+} from '../../../presentation/wallet/send/send-select-asset';
+import { balancesSelector } from '../selectors/balance.selector';
+
+const mapStateToProps = (state: RootReducerState): SendSelectAssetProps => {
+  const balances = balancesSelector(state);
+  const getAsset = assetGetterFromIAssets(state.assets);
+  return {
+    network: state.app.network,
+    balanceAssets: Object.keys(balances).map(getAsset),
+    balances,
+  };
+};
+
+const SendSelectAsset = connect(mapStateToProps)(SendSelectAssetView);
+
+export default SendSelectAsset;

--- a/src/application/redux/reducers/asset-reducer.ts
+++ b/src/application/redux/reducers/asset-reducer.ts
@@ -17,6 +17,7 @@ export const assetInitState: IAssets = {
     name: 'Liquid Bitcoin',
     precision: 8,
     ticker: 'L-BTC',
+    isRegtestAsset: true,
   },
 };
 

--- a/src/domain/assets.ts
+++ b/src/domain/assets.ts
@@ -1,10 +1,12 @@
 import { defaultPrecision } from './../application/utils/constants';
+import { Network } from './network';
 export type IAssets = Record<string, Asset>;
 
 export type Asset = {
   name: string;
   precision: number;
   ticker: string;
+  isRegtestAsset?: boolean;
 };
 
 export type AssetGetter = (assetHash: string) => Asset & { assetHash: string };

--- a/src/domain/assets.ts
+++ b/src/domain/assets.ts
@@ -1,5 +1,4 @@
 import { defaultPrecision } from './../application/utils/constants';
-import { Network } from './network';
 export type IAssets = Record<string, Asset>;
 
 export type Asset = {

--- a/src/presentation/components/asset-list-screen.tsx
+++ b/src/presentation/components/asset-list-screen.tsx
@@ -15,9 +15,16 @@ export interface AssetListProps {
   assets: Array<Asset & { assetHash: string }>; // the assets to display
   onClick: (assetHash: string) => Promise<void>;
   balances?: BalancesByAsset;
+  title: string;
 }
 
-const AssetListScreen: React.FC<AssetListProps> = ({ onClick, network, assets, balances }) => {
+const AssetListScreen: React.FC<AssetListProps> = ({
+  title,
+  onClick,
+  network,
+  assets,
+  balances,
+}) => {
   const history = useHistory();
 
   // Filter assets
@@ -51,6 +58,7 @@ const AssetListScreen: React.FC<AssetListProps> = ({ onClick, network, assets, b
       backBtnCb={handleBackBtn}
       backgroundImagePath="/assets/images/popup/bg-wave-bottom-sm.png"
       className="h-popupContent bg-primary container mx-auto text-center bg-bottom bg-no-repeat"
+      currentPage="select asset"
     >
       <InputIcon
         className="my-4"
@@ -61,7 +69,7 @@ const AssetListScreen: React.FC<AssetListProps> = ({ onClick, network, assets, b
       />
 
       <div className="h-96 pb-1">
-        <ButtonList title="Assets" emptyText="no assets to display...">
+        <ButtonList title={title} emptyText="no assets to display...">
           {searchResults.map((asset, index) => (
             <ButtonAsset
               assetImgPath={

--- a/src/presentation/components/asset-list-screen.tsx
+++ b/src/presentation/components/asset-list-screen.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect } from 'react';
+import { useHistory } from 'react-router';
+import { DEFAULT_ROUTE, SEND_ADDRESS_AMOUNT_ROUTE } from '../routes/constants';
+import ButtonAsset from './button-asset';
+import InputIcon from './input-icon';
+import ShellPopUp from './shell-popup';
+import { imgPathMapMainnet, imgPathMapRegtest } from '../../application/utils';
+import { useDispatch } from 'react-redux';
+import { BalancesByAsset } from '../../application/redux/selectors/balance.selector';
+import { setAsset } from '../../application/redux/actions/transaction';
+import { Network } from '../../domain/network';
+import { ProxyStoreDispatch } from '../../application/redux/proxyStore';
+import { Asset } from '../../domain/assets';
+import ButtonList from './button-list';
+
+export interface AssetListProps {
+  network: Network;
+  assets: Array<Asset & { assetHash: string }>; // the assets to display
+  onClick: (assetHash: string) => Promise<void>;
+  balances?: BalancesByAsset;
+}
+
+const AssetListScreen: React.FC<AssetListProps> = ({ onClick, network, assets, balances }) => {
+  const history = useHistory();
+
+  const dispatch = useDispatch<ProxyStoreDispatch>();
+
+  // Filter assets
+  const [searchTerm, setSearchTerm] = React.useState('');
+  const [searchResults, setSearchResults] = React.useState(assets);
+
+  useEffect(() => {
+    if (!searchTerm) {
+      setSearchResults(assets);
+    }
+
+    const results = assets.filter(
+      (a) =>
+        a.name.toLowerCase().includes(searchTerm) || a.ticker.toLowerCase().includes(searchTerm)
+    );
+
+    setSearchResults(results);
+  }, [searchTerm]);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const searchTerm = event.target.value.toLowerCase().replace('-', '');
+    setSearchTerm(searchTerm);
+  };
+
+  const handleBackBtn = () => {
+    history.push(DEFAULT_ROUTE);
+  };
+
+  return (
+    <ShellPopUp
+      backBtnCb={handleBackBtn}
+      backgroundImagePath="/assets/images/popup/bg-wave-bottom-sm.png"
+      className="h-popupContent bg-primary container mx-auto text-center bg-bottom bg-no-repeat"
+      currentPage="Select asset"
+    >
+      <InputIcon
+        className="my-8"
+        imgIconPath="assets/images/search.svg"
+        imgIconAlt="search"
+        onChange={handleChange}
+        type="search"
+      />
+
+      <div className="h-25.75 overflow-y-scroll">
+        <div className="pb-4 space-y-4">
+          <ButtonList title="Assets" emptyText="no assets to display...">
+            {searchResults.map((asset) => (
+              <ButtonAsset
+                assetImgPath={
+                  network === 'regtest'
+                    ? imgPathMapRegtest[asset.ticker] ?? imgPathMapRegtest['']
+                    : imgPathMapMainnet[asset.assetHash] ?? imgPathMapMainnet['']
+                }
+                assetHash={asset.assetHash}
+                assetName={asset.name}
+                assetTicker={asset.ticker}
+                assetPrecision={asset.precision}
+                quantity={balances ? balances[asset.assetHash] : undefined}
+                key={asset.assetHash}
+                handleClick={({ assetHash }) => onClick(assetHash as string)}
+              />
+            ))}
+          </ButtonList>
+        </div>
+      </div>
+    </ShellPopUp>
+  );
+};
+
+export default AssetListScreen;

--- a/src/presentation/components/asset-list-screen.tsx
+++ b/src/presentation/components/asset-list-screen.tsx
@@ -1,15 +1,12 @@
 import React, { useEffect } from 'react';
 import { useHistory } from 'react-router';
-import { DEFAULT_ROUTE, SEND_ADDRESS_AMOUNT_ROUTE } from '../routes/constants';
+import { DEFAULT_ROUTE } from '../routes/constants';
 import ButtonAsset from './button-asset';
 import InputIcon from './input-icon';
 import ShellPopUp from './shell-popup';
 import { imgPathMapMainnet, imgPathMapRegtest } from '../../application/utils';
-import { useDispatch } from 'react-redux';
 import { BalancesByAsset } from '../../application/redux/selectors/balance.selector';
-import { setAsset } from '../../application/redux/actions/transaction';
 import { Network } from '../../domain/network';
-import { ProxyStoreDispatch } from '../../application/redux/proxyStore';
 import { Asset } from '../../domain/assets';
 import ButtonList from './button-list';
 
@@ -22,8 +19,6 @@ export interface AssetListProps {
 
 const AssetListScreen: React.FC<AssetListProps> = ({ onClick, network, assets, balances }) => {
   const history = useHistory();
-
-  const dispatch = useDispatch<ProxyStoreDispatch>();
 
   // Filter assets
   const [searchTerm, setSearchTerm] = React.useState('');
@@ -56,37 +51,34 @@ const AssetListScreen: React.FC<AssetListProps> = ({ onClick, network, assets, b
       backBtnCb={handleBackBtn}
       backgroundImagePath="/assets/images/popup/bg-wave-bottom-sm.png"
       className="h-popupContent bg-primary container mx-auto text-center bg-bottom bg-no-repeat"
-      currentPage="Select asset"
     >
       <InputIcon
-        className="my-8"
+        className="my-4"
         imgIconPath="assets/images/search.svg"
         imgIconAlt="search"
         onChange={handleChange}
         type="search"
       />
 
-      <div className="h-25.75 overflow-y-scroll">
-        <div className="pb-4 space-y-4">
-          <ButtonList title="Assets" emptyText="no assets to display...">
-            {searchResults.map((asset) => (
-              <ButtonAsset
-                assetImgPath={
-                  network === 'regtest'
-                    ? imgPathMapRegtest[asset.ticker] ?? imgPathMapRegtest['']
-                    : imgPathMapMainnet[asset.assetHash] ?? imgPathMapMainnet['']
-                }
-                assetHash={asset.assetHash}
-                assetName={asset.name}
-                assetTicker={asset.ticker}
-                assetPrecision={asset.precision}
-                quantity={balances ? balances[asset.assetHash] : undefined}
-                key={asset.assetHash}
-                handleClick={({ assetHash }) => onClick(assetHash as string)}
-              />
-            ))}
-          </ButtonList>
-        </div>
+      <div className="h-96 pb-1">
+        <ButtonList title="Assets" emptyText="no assets to display...">
+          {searchResults.map((asset, index) => (
+            <ButtonAsset
+              assetImgPath={
+                network === 'regtest'
+                  ? imgPathMapRegtest[asset.ticker] ?? imgPathMapRegtest['']
+                  : imgPathMapMainnet[asset.assetHash] ?? imgPathMapMainnet['']
+              }
+              assetHash={asset.assetHash}
+              assetName={asset.name}
+              assetTicker={asset.ticker}
+              assetPrecision={asset.precision}
+              quantity={balances ? balances[asset.assetHash] : undefined}
+              key={index}
+              handleClick={({ assetHash }) => onClick(assetHash as string)}
+            />
+          ))}
+        </ButtonList>
       </div>
     </ShellPopUp>
   );

--- a/src/presentation/components/button-asset.tsx
+++ b/src/presentation/components/button-asset.tsx
@@ -12,7 +12,7 @@ interface Props {
     assetHash,
     assetName,
     assetTicker,
-    assetPrecision
+    assetPrecision,
   }: {
     [key: string]: string | number;
   }) => void;
@@ -29,7 +29,7 @@ const ButtonAsset: React.FC<Props> = ({
   disabled = false,
   quantity,
   handleClick,
-  type = 'button'
+  type = 'button',
 }: Props) => {
   return (
     <button

--- a/src/presentation/components/button-asset.tsx
+++ b/src/presentation/components/button-asset.tsx
@@ -12,12 +12,12 @@ interface Props {
     assetHash,
     assetName,
     assetTicker,
-    assetPrecision,
+    assetPrecision
   }: {
     [key: string]: string | number;
   }) => void;
   type?: 'submit' | 'button' | 'reset';
-  quantity: number;
+  quantity?: number;
 }
 
 const ButtonAsset: React.FC<Props> = ({
@@ -29,7 +29,7 @@ const ButtonAsset: React.FC<Props> = ({
   disabled = false,
   quantity,
   handleClick,
-  type = 'button',
+  type = 'button'
 }: Props) => {
   return (
     <button
@@ -46,9 +46,11 @@ const ButtonAsset: React.FC<Props> = ({
         </div>
       </div>
       <div className="flex flex-row">
-        <div className="text-small font-medium">
-          {formatDecimalAmount(fromSatoshi(quantity, assetPrecision))}
-        </div>
+        {quantity && (
+          <div className="text-small font-medium">
+            {formatDecimalAmount(fromSatoshi(quantity, assetPrecision))}
+          </div>
+        )}
         <img className="ml-1.5" src="assets/images/chevron-right.svg" alt="chevron-right" />
       </div>
     </button>

--- a/src/presentation/components/button-list.tsx
+++ b/src/presentation/components/button-list.tsx
@@ -3,19 +3,17 @@ import React from 'react';
 interface Props {
   children?: React.ReactElement | React.ReactElement[];
   title: string;
-  type: 'assets' | 'transactions';
+  emptyText: string;
 }
 
-const ButtonList: React.FC<Props> = ({ children, title, type }: Props) => {
+const ButtonList: React.FC<Props> = ({ children, title, emptyText }: Props) => {
   return (
     <div>
       <h2 className="mt-2 text-lg font-medium text-left text-white">{title}</h2>
       <div className="h-64 overflow-y-auto" id="btn-list">
         <div className="py-4 space-y-4">
           {React.Children.count(children) === 0 ? (
-            <span className="text-sm font-medium text-white">
-              Your transactions will appear here
-            </span>
+            <span className="text-sm font-medium text-white">{emptyText}</span>
           ) : (
             children
           )}

--- a/src/presentation/components/button-list.tsx
+++ b/src/presentation/components/button-list.tsx
@@ -8,9 +8,9 @@ interface Props {
 
 const ButtonList: React.FC<Props> = ({ children, title, emptyText }: Props) => {
   return (
-    <div>
+    <div className="h-full">
       <h2 className="mt-2 text-lg font-medium text-left text-white">{title}</h2>
-      <div className="h-64 overflow-y-auto" id="btn-list">
+      <div className="h-full overflow-y-auto" id="btn-list">
         <div className="py-4 space-y-4">
           {React.Children.count(children) === 0 ? (
             <span className="text-sm font-medium text-white">{emptyText}</span>

--- a/src/presentation/routes/constants.ts
+++ b/src/presentation/routes/constants.ts
@@ -21,8 +21,9 @@ const BACKUP_UNLOCK_ROUTE = '/backup-unlock';
 const LOGIN_ROUTE = '/login';
 const DEFAULT_ROUTE = '/';
 const TRANSACTIONS_ROUTE = '/transactions';
-const RECEIVE_ROUTE = '/receive';
-const SELECT_ASSET_ROUTE = '/select-asset';
+const RECEIVE_SELECT_ASSET_ROUTE = '/receive/select-asset';
+const RECEIVE_ADDRESS_ROUTE = '/receive/address';
+const SEND_SELECT_ASSET_ROUTE = '/send/select-asset';
 const SEND_ADDRESS_AMOUNT_ROUTE = '/send';
 const SEND_CHOOSE_FEE_ROUTE = '/send/choose-fee';
 const SEND_CONFIRMATION_ROUTE = '/send/confirmation';
@@ -64,8 +65,9 @@ export {
   LOGIN_ROUTE,
   DEFAULT_ROUTE,
   TRANSACTIONS_ROUTE,
-  RECEIVE_ROUTE,
-  SELECT_ASSET_ROUTE,
+  RECEIVE_SELECT_ASSET_ROUTE,
+  RECEIVE_ADDRESS_ROUTE,
+  SEND_SELECT_ASSET_ROUTE,
   SEND_ADDRESS_AMOUNT_ROUTE,
   SEND_CHOOSE_FEE_ROUTE,
   SEND_CONFIRMATION_ROUTE,

--- a/src/presentation/routes/index.tsx
+++ b/src/presentation/routes/index.tsx
@@ -16,8 +16,8 @@ import {
   DEFAULT_ROUTE,
   LOGIN_ROUTE,
   TRANSACTIONS_ROUTE,
-  RECEIVE_ROUTE,
-  SELECT_ASSET_ROUTE,
+  RECEIVE_SELECT_ASSET_ROUTE,
+  SEND_SELECT_ASSET_ROUTE,
   SEND_ADDRESS_AMOUNT_ROUTE,
   SEND_CHOOSE_FEE_ROUTE,
   SEND_CONFIRMATION_ROUTE,
@@ -36,6 +36,7 @@ import {
   SEND_PAYMENT_ERROR_ROUTE,
   BACKUP_UNLOCK_ROUTE,
   SETTINGS_DEEP_RESTORER_ROUTE,
+  RECEIVE_ADDRESS_ROUTE,
 } from './constants';
 
 // Connect
@@ -57,8 +58,9 @@ import BackUpUnlock from '../onboarding/backup-unlock';
 import Home from '../../application/redux/containers/home.container';
 import LogIn from '../wallet/log-in';
 import Transactions from '../../application/redux/containers/transactions.container';
-import Receive from '../../application/redux/containers/receive.container';
-import SelectAsset from '../../application/redux/containers/select-asset.container';
+import ReceiveAddress from '../../application/redux/containers/receive.container';
+import ReceiveSelectAsset from '../../application/redux/containers/receive-select-asset.container';
+import SendSelectAsset from '../../application/redux/containers/send-select-asset.container';
 import AddressAmount from '../../application/redux/containers/address-amount.container';
 import ChooseFee from '../../application/redux/containers/choose-fee.container';
 import Confirmation from '../../application/redux/containers/confirmation.container';
@@ -93,8 +95,9 @@ const Routes: React.FC = () => {
       {/*Wallet*/}
       <ProtectedRoute exact path={DEFAULT_ROUTE} comp={Home} />
       <ProtectedRoute exact path={TRANSACTIONS_ROUTE} comp={Transactions} />
-      <ProtectedRoute exact path={RECEIVE_ROUTE} comp={Receive} />
-      <ProtectedRoute exact path={SELECT_ASSET_ROUTE} comp={SelectAsset} />
+      <ProtectedRoute exact path={RECEIVE_SELECT_ASSET_ROUTE} comp={ReceiveSelectAsset} />
+      <ProtectedRoute exact path={RECEIVE_ADDRESS_ROUTE} comp={ReceiveAddress} />
+      <ProtectedRoute exact path={SEND_SELECT_ASSET_ROUTE} comp={SendSelectAsset} />
       <ProtectedRoute exact path={SEND_ADDRESS_AMOUNT_ROUTE} comp={AddressAmount} />
       <ProtectedRoute exact path={SEND_CHOOSE_FEE_ROUTE} comp={ChooseFee} />
       <ProtectedRoute exact path={SEND_CONFIRMATION_ROUTE} comp={Confirmation} />

--- a/src/presentation/wallet/home/index.tsx
+++ b/src/presentation/wallet/home/index.tsx
@@ -92,7 +92,7 @@ const HomeView: React.FC<HomeProps> = ({
       className="container mx-auto text-center bg-bottom bg-no-repeat"
       hasBackBtn={false}
     >
-      <div className="h-popupContent flex flex-col justify-between">
+      <div className="h-popupContent">
         <div>
           <Balance
             assetHash={lbtcAssetHash}
@@ -105,8 +105,10 @@ const HomeView: React.FC<HomeProps> = ({
           <ButtonsSendReceive onReceive={handleReceive} onSend={handleSend} />
         </div>
 
-        <div>
-          <div className="w-48 mx-auto border-b-0.5 border-white pt-1.5" />
+        <br />
+        <div className="w-48 mx-auto border-b-0.5 border-white pt-1.5" />
+
+        <div className="h-60">
           <ButtonList title="Assets" emptyText="You don't own any asset...">
             {Object.entries(assetsBalance)
               .sort(([a], [b]) => (a === lbtcAssetHash ? -Infinity : Infinity))

--- a/src/presentation/wallet/home/index.tsx
+++ b/src/presentation/wallet/home/index.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router';
 import {
   BACKUP_UNLOCK_ROUTE,
-  RECEIVE_ROUTE,
-  SELECT_ASSET_ROUTE,
+  RECEIVE_SELECT_ASSET_ROUTE,
+  SEND_SELECT_ASSET_ROUTE,
   SEND_ADDRESS_AMOUNT_ROUTE,
   SEND_CHOOSE_FEE_ROUTE,
   SEND_CONFIRMATION_ROUTE,
@@ -66,11 +66,11 @@ const HomeView: React.FC<HomeProps> = ({
     if (!isWalletVerified) {
       showSaveMnemonicModal(true);
     } else {
-      history.push(RECEIVE_ROUTE);
+      history.push(RECEIVE_SELECT_ASSET_ROUTE);
     }
   };
 
-  const handleSend = () => history.push(SELECT_ASSET_ROUTE);
+  const handleSend = () => history.push(SEND_SELECT_ASSET_ROUTE);
 
   useEffect(() => {
     switch (transactionStep) {

--- a/src/presentation/wallet/home/index.tsx
+++ b/src/presentation/wallet/home/index.tsx
@@ -7,7 +7,7 @@ import {
   SEND_ADDRESS_AMOUNT_ROUTE,
   SEND_CHOOSE_FEE_ROUTE,
   SEND_CONFIRMATION_ROUTE,
-  TRANSACTIONS_ROUTE,
+  TRANSACTIONS_ROUTE
 } from '../../routes/constants';
 import Balance from '../../components/balance';
 import ButtonAsset from '../../components/button-asset';
@@ -38,7 +38,7 @@ const HomeView: React.FC<HomeProps> = ({
   transactionStep,
   assetsBalance,
   network,
-  isWalletVerified,
+  isWalletVerified
 }) => {
   const history = useHistory();
   const [isSaveMnemonicModalOpen, showSaveMnemonicModal] = useState(false);
@@ -51,8 +51,8 @@ const HomeView: React.FC<HomeProps> = ({
         assetsBalance,
         assetHash,
         assetTicker,
-        assetPrecision,
-      },
+        assetPrecision
+      }
     });
   };
 
@@ -107,7 +107,7 @@ const HomeView: React.FC<HomeProps> = ({
 
         <div>
           <div className="w-48 mx-auto border-b-0.5 border-white pt-1.5" />
-          <ButtonList title="Assets" type="assets">
+          <ButtonList title="Assets" emptyText="You don't own any asset...">
             {Object.entries(assetsBalance)
               .sort(([a], [b]) => (a === lbtcAssetHash ? -Infinity : Infinity))
               .map(([asset, balance]) => {

--- a/src/presentation/wallet/home/index.tsx
+++ b/src/presentation/wallet/home/index.tsx
@@ -7,7 +7,7 @@ import {
   SEND_ADDRESS_AMOUNT_ROUTE,
   SEND_CHOOSE_FEE_ROUTE,
   SEND_CONFIRMATION_ROUTE,
-  TRANSACTIONS_ROUTE
+  TRANSACTIONS_ROUTE,
 } from '../../routes/constants';
 import Balance from '../../components/balance';
 import ButtonAsset from '../../components/button-asset';
@@ -38,7 +38,7 @@ const HomeView: React.FC<HomeProps> = ({
   transactionStep,
   assetsBalance,
   network,
-  isWalletVerified
+  isWalletVerified,
 }) => {
   const history = useHistory();
   const [isSaveMnemonicModalOpen, showSaveMnemonicModal] = useState(false);
@@ -51,8 +51,8 @@ const HomeView: React.FC<HomeProps> = ({
         assetsBalance,
         assetHash,
         assetTicker,
-        assetPrecision
-      }
+        assetPrecision,
+      },
     });
   };
 

--- a/src/presentation/wallet/receive/receive-select-asset.tsx
+++ b/src/presentation/wallet/receive/receive-select-asset.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useHistory } from 'react-router';
+import { RECEIVE_ADDRESS_ROUTE } from '../../routes/constants';
+import { Network } from '../../../domain/network';
+import { Asset } from '../../../domain/assets';
+import AssetListScreen from '../../components/asset-list-screen';
+
+export interface ReceiveSelectAssetProps {
+  network: Network;
+  assets: Array<Asset & { assetHash: string }>;
+}
+
+const ReceiveSelectAssetView: React.FC<ReceiveSelectAssetProps> = ({ network, assets }) => {
+  const history = useHistory();
+
+  const handleSend = async (assetHash: string) => {
+    history.push(RECEIVE_ADDRESS_ROUTE);
+  };
+
+  return (
+    <AssetListScreen title="Receive Asset" onClick={handleSend} network={network} assets={assets} />
+  );
+};
+
+export default ReceiveSelectAssetView;

--- a/src/presentation/wallet/receive/receive-select-asset.tsx
+++ b/src/presentation/wallet/receive/receive-select-asset.tsx
@@ -13,13 +13,25 @@ export interface ReceiveSelectAssetProps {
 const ReceiveSelectAssetView: React.FC<ReceiveSelectAssetProps> = ({ network, assets }) => {
   const history = useHistory();
 
-  const handleSend = async (assetHash: string) => {
-    history.push(RECEIVE_ADDRESS_ROUTE);
+  const handleSend = (_: string) => {
+    return Promise.resolve(history.push(RECEIVE_ADDRESS_ROUTE));
   };
 
   return (
-    <AssetListScreen title="Receive Asset" onClick={handleSend} network={network} assets={assets} />
+    <AssetListScreen
+      title="Receive Asset"
+      onClick={handleSend}
+      network={network}
+      assets={[UnknowAsset].concat(assets)}
+    />
   );
+};
+
+const UnknowAsset: Asset & { assetHash: string } = {
+  ticker: 'Any',
+  name: 'New asset',
+  precision: 8,
+  assetHash: 'new_asset',
 };
 
 export default ReceiveSelectAssetView;

--- a/src/presentation/wallet/send/select-asset.tsx
+++ b/src/presentation/wallet/send/select-asset.tsx
@@ -1,10 +1,6 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useHistory } from 'react-router';
-import { DEFAULT_ROUTE, SEND_ADDRESS_AMOUNT_ROUTE } from '../../routes/constants';
-import ButtonAsset from '../../components/button-asset';
-import InputIcon from '../../components/input-icon';
-import ShellPopUp from '../../components/shell-popup';
-import { imgPathMapMainnet, imgPathMapRegtest } from '../../../application/utils';
+import { SEND_ADDRESS_AMOUNT_ROUTE } from '../../routes/constants';
 import { useDispatch } from 'react-redux';
 import { BalancesByAsset } from '../../../application/redux/selectors/balance.selector';
 import { setAsset } from '../../../application/redux/actions/transaction';

--- a/src/presentation/wallet/send/select-asset.tsx
+++ b/src/presentation/wallet/send/select-asset.tsx
@@ -11,6 +11,7 @@ import { setAsset } from '../../../application/redux/actions/transaction';
 import { Network } from '../../../domain/network';
 import { ProxyStoreDispatch } from '../../../application/redux/proxyStore';
 import { Asset } from '../../../domain/assets';
+import AssetListScreen from '../../components/asset-list-screen';
 
 export interface SelectAssetProps {
   network: Network;
@@ -22,73 +23,18 @@ const SelectAssetView: React.FC<SelectAssetProps> = ({ network, balanceAssets, b
   const history = useHistory();
   const dispatch = useDispatch<ProxyStoreDispatch>();
 
-  // Filter assets
-  const [searchTerm, setSearchTerm] = React.useState('');
-  const [searchResults, setSearchResults] = React.useState(balanceAssets);
-
-  useEffect(() => {
-    if (!searchTerm) {
-      setSearchResults(balanceAssets);
-    }
-
-    const results = balanceAssets.filter(
-      (a) =>
-        a.name.toLowerCase().includes(searchTerm) || a.ticker.toLowerCase().includes(searchTerm)
-    );
-
-    setSearchResults(results);
-  }, [searchTerm]);
-
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const searchTerm = event.target.value.toLowerCase().replace('-', '');
-    setSearchTerm(searchTerm);
-  };
-
   const handleSend = async (assetHash: string) => {
     await dispatch(setAsset(assetHash));
     history.push(SEND_ADDRESS_AMOUNT_ROUTE);
   };
 
-  const handleBackBtn = () => {
-    history.push(DEFAULT_ROUTE);
-  };
-
   return (
-    <ShellPopUp
-      backBtnCb={handleBackBtn}
-      backgroundImagePath="/assets/images/popup/bg-wave-bottom-sm.png"
-      className="h-popupContent bg-primary container mx-auto text-center bg-bottom bg-no-repeat"
-      currentPage="Select asset"
-    >
-      <InputIcon
-        className="my-8"
-        imgIconPath="assets/images/search.svg"
-        imgIconAlt="search"
-        onChange={handleChange}
-        type="search"
-      />
-
-      <div className="h-25.75 overflow-y-scroll">
-        <div className="pb-4 space-y-4">
-          {searchResults.map((asset) => (
-            <ButtonAsset
-              assetImgPath={
-                network === 'regtest'
-                  ? imgPathMapRegtest[asset.ticker] ?? imgPathMapRegtest['']
-                  : imgPathMapMainnet[asset.assetHash] ?? imgPathMapMainnet['']
-              }
-              assetHash={asset.assetHash}
-              assetName={asset.name}
-              assetTicker={asset.ticker}
-              assetPrecision={asset.precision}
-              quantity={balances[asset.assetHash]}
-              key={asset.assetHash}
-              handleClick={({ assetHash }) => handleSend(assetHash as string)}
-            />
-          ))}
-        </div>
-      </div>
-    </ShellPopUp>
+    <AssetListScreen
+      onClick={handleSend}
+      network={network}
+      assets={balanceAssets}
+      balances={balances}
+    />
   );
 };
 

--- a/src/presentation/wallet/send/select-asset.tsx
+++ b/src/presentation/wallet/send/select-asset.tsx
@@ -30,6 +30,7 @@ const SelectAssetView: React.FC<SelectAssetProps> = ({ network, balanceAssets, b
 
   return (
     <AssetListScreen
+      title="Send Asset"
       onClick={handleSend}
       network={network}
       assets={balanceAssets}

--- a/src/presentation/wallet/send/send-select-asset.tsx
+++ b/src/presentation/wallet/send/send-select-asset.tsx
@@ -9,13 +9,17 @@ import { ProxyStoreDispatch } from '../../../application/redux/proxyStore';
 import { Asset } from '../../../domain/assets';
 import AssetListScreen from '../../components/asset-list-screen';
 
-export interface SelectAssetProps {
+export interface SendSelectAssetProps {
   network: Network;
   balances: BalancesByAsset;
   balanceAssets: Array<Asset & { assetHash: string }>;
 }
 
-const SelectAssetView: React.FC<SelectAssetProps> = ({ network, balanceAssets, balances }) => {
+const SendSelectAssetView: React.FC<SendSelectAssetProps> = ({
+  network,
+  balanceAssets,
+  balances,
+}) => {
   const history = useHistory();
   const dispatch = useDispatch<ProxyStoreDispatch>();
 
@@ -35,4 +39,4 @@ const SelectAssetView: React.FC<SelectAssetProps> = ({ network, balanceAssets, b
   );
 };
 
-export default SelectAssetView;
+export default SendSelectAssetView;

--- a/src/presentation/wallet/transactions/index.tsx
+++ b/src/presentation/wallet/transactions/index.tsx
@@ -1,7 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import browser from 'webextension-polyfill';
-import { DEFAULT_ROUTE, RECEIVE_ROUTE, SEND_ADDRESS_AMOUNT_ROUTE } from '../../routes/constants';
+import {
+  DEFAULT_ROUTE,
+  RECEIVE_ADDRESS_ROUTE,
+  SEND_ADDRESS_AMOUNT_ROUTE,
+} from '../../routes/constants';
 import Balance from '../../components/balance';
 import Button from '../../components/button';
 import ButtonList from '../../components/button-list';
@@ -57,7 +61,7 @@ const TransactionsView: React.FC<TransactionsProps> = ({
   // Save mnemonic modal
   const [isSaveMnemonicModalOpen, showSaveMnemonicModal] = useState(false);
   const handleSaveMnemonicClose = () => showSaveMnemonicModal(false);
-  const handleSaveMnemonicConfirm = () => history.push(RECEIVE_ROUTE);
+  const handleSaveMnemonicConfirm = () => history.push(RECEIVE_ADDRESS_ROUTE);
   const handleReceive = () => showSaveMnemonicModal(true);
   const handleSend = async () => {
     await dispatch(setAsset(state.assetHash));

--- a/src/presentation/wallet/transactions/index.tsx
+++ b/src/presentation/wallet/transactions/index.tsx
@@ -98,31 +98,33 @@ const TransactionsView: React.FC<TransactionsProps> = ({
 
       <div className="w-48 mx-auto border-b-0.5 border-white pt-1.5" />
 
-      <ButtonList title="Transactions" emptyText="Your transactions will appear here">
-        {transactions
-          .filter(txHasAsset(state.assetHash))
-          // Descending order
-          .sort((a, b) => {
-            if (!a.blockTimeMs || !b.blockTimeMs) return 0;
-            const momentB = moment(b.blockTimeMs);
-            const momentA = moment(a.blockTimeMs);
-            return momentB.diff(momentA);
-          })
-          .map((tx, index) => {
-            return (
-              <ButtonTransaction
-                assetHash={state.assetHash}
-                assetPrecision={state.assetPrecision}
-                assetTicker={state.assetTicker}
-                key={index}
-                handleClick={() => {
-                  setModalTxDetails(tx);
-                }}
-                tx={tx}
-              />
-            );
-          })}
-      </ButtonList>
+      <div className="h-60 rounded-xl mb-1">
+        <ButtonList title="Transactions" emptyText="Your transactions will appear here">
+          {transactions
+            .filter(txHasAsset(state.assetHash))
+            // Descending order
+            .sort((a, b) => {
+              if (!a.blockTimeMs || !b.blockTimeMs) return 0;
+              const momentB = moment(b.blockTimeMs);
+              const momentA = moment(a.blockTimeMs);
+              return momentB.diff(momentA);
+            })
+            .map((tx, index) => {
+              return (
+                <ButtonTransaction
+                  assetHash={state.assetHash}
+                  assetPrecision={state.assetPrecision}
+                  assetTicker={state.assetTicker}
+                  key={index}
+                  handleClick={() => {
+                    setModalTxDetails(tx);
+                  }}
+                  tx={tx}
+                />
+              );
+            })}
+        </ButtonList>
+      </div>
 
       <Modal isOpen={modalTxDetails !== undefined} onClose={() => setModalTxDetails(undefined)}>
         <div className="mx-auto text-center">

--- a/src/presentation/wallet/transactions/index.tsx
+++ b/src/presentation/wallet/transactions/index.tsx
@@ -40,7 +40,7 @@ const TransactionsView: React.FC<TransactionsProps> = ({
   assets,
   transactions,
   network,
-  webExplorerURL,
+  webExplorerURL
 }) => {
   const history = useHistory();
   const { state } = useLocation<LocationState>();
@@ -98,7 +98,7 @@ const TransactionsView: React.FC<TransactionsProps> = ({
 
       <div className="w-48 mx-auto border-b-0.5 border-white pt-1.5" />
 
-      <ButtonList title="Transactions" type="transactions">
+      <ButtonList title="Transactions" emptyText="Your transactions will appear here">
         {transactions
           .filter(txHasAsset(state.assetHash))
           // Descending order

--- a/src/presentation/wallet/transactions/index.tsx
+++ b/src/presentation/wallet/transactions/index.tsx
@@ -40,7 +40,7 @@ const TransactionsView: React.FC<TransactionsProps> = ({
   assets,
   transactions,
   network,
-  webExplorerURL
+  webExplorerURL,
 }) => {
   const history = useHistory();
   const { state } = useLocation<LocationState>();


### PR DESCRIPTION
**This PR uses the `AssetListScreen` component from send flow to receive flow in order to add a step before generating wallet addresses**

- abstract the `SelectAsset` screen in order to reuse it in `send-select-asset.tsx` and `receive-select-asset.tsx`.
- add `ButtonList` component (= use the same scrollbar)
- some CSS changes on Home and Transactions views (due to some abstraction in `ButtonList`).
- ATM, the addresses derivation paths do not include the asset type. So all the assets buttons have the same behavior now in `receive-select-asset.tsx`.

it closes #226 

@tiero please review