### PR TITLE
Return public key in SignedMessage (marina-provider 1.4.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ldk": "^0.3.9",
     "lodash.debounce": "^4.0.8",
     "lottie-web": "^5.7.8",
-    "marina-provider": "^1.4.0",
+    "marina-provider": "^1.4.2",
     "moment": "^2.29.1",
     "path-browserify": "^1.0.1",
     "postcss": "^7.0.35",

--- a/src/application/utils/message.ts
+++ b/src/application/utils/message.ts
@@ -2,12 +2,13 @@ import * as bip32 from 'bip32';
 import * as bip39 from 'bip39';
 import { networks, payments } from 'ldk';
 import * as bitcoinMessage from 'bitcoinjs-message';
+import { SignedMessage } from 'marina-provider';
 
 export async function signMessageWithMnemonic(
   message: string,
   mnemonic: string,
   network: networks.Network
-): Promise<{ signature: string; address: string }> {
+): Promise<SignedMessage> {
   const seed = await bip39.mnemonicToSeed(mnemonic);
   const node = bip32.fromSeed(seed, network);
   const child = node.derivePath("m/84'/0'/0'/0/0");
@@ -16,5 +17,9 @@ export async function signMessageWithMnemonic(
   });
 
   const pay = payments.p2wpkh({ pubkey: child.publicKey, network });
-  return { signature: signature.toString('base64'), address: pay.address! };
+  return {
+    signature: signature.toString('base64'),
+    address: pay.address!,
+    publicKey: child.publicKey.toString('hex'),
+  };
 }

--- a/src/presentation/connect/sign-msg.tsx
+++ b/src/presentation/connect/sign-msg.tsx
@@ -13,13 +13,14 @@ import { Network } from 'liquidjs-lib';
 import { useSelector } from 'react-redux';
 import { RootReducerState } from '../../domain/common';
 import PopupWindowProxy from './popupWindowProxy';
+import { SignedMessage } from 'marina-provider';
 
 function signMsgWithPassword(
   message: string,
   encryptedMnemonic: string,
   password: string,
   network: Network
-): Promise<{ signature: string; address: string }> {
+): Promise<SignedMessage> {
   try {
     const mnemonic = decrypt(encryptedMnemonic, password);
     return signMessageWithMnemonic(message, mnemonic, network);
@@ -30,7 +31,7 @@ function signMsgWithPassword(
 
 export interface SignMessagePopupResponse {
   accepted: boolean;
-  signedMessage?: string;
+  signedMessage?: SignedMessage;
 }
 
 const ConnectSignMsg: React.FC<WithConnectDataProps> = ({ connectData }) => {
@@ -46,7 +47,7 @@ const ConnectSignMsg: React.FC<WithConnectDataProps> = ({ connectData }) => {
   const handleModalUnlockClose = () => showUnlockModal(false);
   const handleUnlockModalOpen = () => showUnlockModal(true);
 
-  const sendResponseMessage = (accepted: boolean, signedMessage?: string) => {
+  const sendResponseMessage = (accepted: boolean, signedMessage?: SignedMessage) => {
     return popupWindowProxy.sendResponse({ data: { accepted, signedMessage } });
   };
 
@@ -72,7 +73,7 @@ const ConnectSignMsg: React.FC<WithConnectDataProps> = ({ connectData }) => {
         password,
         networkFromString(network)
       );
-      await sendResponseMessage(true, signedMsg.signature);
+      await sendResponseMessage(true, signedMsg);
       window.close();
     } catch (e: any) {
       console.error(e);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6340,10 +6340,10 @@ marina-provider@^1.0.0:
   resolved "https://registry.yarnpkg.com/marina-provider/-/marina-provider-1.3.0.tgz#ee26222816570e5649457c5eb6f3078433af5cd8"
   integrity sha512-J00cMcynnNwLut8GdbLNHSHR7jKUGcaiJfExgomIDbIMXJD/nZZQlxg8/zzPsAnujMx/aAEqqfEj+h4PIohp9g==
 
-marina-provider@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/marina-provider/-/marina-provider-1.4.0.tgz#ae502bc641a251888270dd393cc06739d5c1e459"
-  integrity sha512-S2kFaFc0GdQ/EneW+dwAv+VP8Tvxsk1qhdM/PTG/I5kC9yJbPB5knv0bqlh/bkIuK7nrmLP9gV1mBddbIRtBcA==
+marina-provider@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/marina-provider/-/marina-provider-1.4.2.tgz#44ccc2aaee79c98d70d9ccf88b57dd275cfa929a"
+  integrity sha512-s+qjzy8pjtuPbAeeLZCUlZXb/aWgkVinlTs8VVyB7yUPI8OXCUAyO8q++LZdahU6s6aRw/yM3qH1MAGFkC6aKA==
 
 marky@^1.2.0:
   version "1.2.2"


### PR DESCRIPTION
This PR returns the public key (hex string) in `marina.signMessage` function. 

it closes #228 

@tiero please review