### PR TITLE
Implement new `sendTransaction` (with data argument)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install Nigiri
-        run: |
-          mkdir -p tmp; cd tmp
-          curl https://travis.nigiri.network | bash; cd ..
-          docker-compose -f  tmp/docker-compose.yml up -d
+        uses: vulpemventures/nigiri-github-action@v1
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ldk": "^0.3.9",
     "lodash.debounce": "^4.0.8",
     "lottie-web": "^5.7.8",
-    "marina-provider": "^1.4.2",
+    "marina-provider": "^1.4.3",
     "moment": "^2.29.1",
     "path-browserify": "^1.0.1",
     "postcss": "^7.0.35",

--- a/src/application/redux/actions/connect.ts
+++ b/src/application/redux/actions/connect.ts
@@ -1,4 +1,5 @@
 import { RecipientInterface } from 'ldk';
+import { DataRecipient } from 'marina-provider';
 import { AnyAction } from 'redux';
 import { ConnectData } from '../../../domain/connect';
 import { Network } from '../../../domain/network';
@@ -10,46 +11,46 @@ import {
   FLUSH_TX,
   SELECT_HOSTNAME,
   SET_MSG,
-  SET_TX_DATA,
+  SET_TX_DATA
 } from './action-types';
 
 export function enableWebsite(hostname: string, network: Network): AnyAction {
   return {
     type: ENABLE_WEBSITE,
-    payload: { hostname, network },
+    payload: { hostname, network }
   };
 }
 
 export function disableWebsite(hostname: string, network: Network): AnyAction {
   return {
     type: DISABLE_WEBSITE,
-    payload: { hostname, network },
+    payload: { hostname, network }
   };
 }
 
 export function setMsg(hostname: string, message: string): AnyAction {
   return {
     type: SET_MSG,
-    payload: { hostname, message },
+    payload: { hostname, message }
   };
 }
 
 export function flushMsg(): AnyAction {
   return {
-    type: FLUSH_MSG,
+    type: FLUSH_MSG
   };
 }
 
 export function flushTx(): AnyAction {
   return {
-    type: FLUSH_TX,
+    type: FLUSH_TX
   };
 }
 
 export function setTx(hostname: string, pset: string): AnyAction {
   return {
     type: SET_TX_DATA,
-    payload: { hostname, pset } as ConnectData['tx'],
+    payload: { hostname, pset } as ConnectData['tx']
   };
 }
 
@@ -58,24 +59,24 @@ export function setTxData(
   recipients: RecipientInterface[],
   feeAssetHash: string,
   network: Network,
-  data: string[]
+  data: DataRecipient[]
 ): AnyAction {
   return {
     type: SET_TX_DATA,
-    payload: { hostname, recipients, feeAssetHash, network, data } as ConnectData['tx'],
+    payload: { hostname, recipients, feeAssetHash, network, data } as ConnectData['tx']
   };
 }
 
 export function selectHostname(hostname: string, network: Network): AnyAction {
   return {
     type: SELECT_HOSTNAME,
-    payload: { hostname, network },
+    payload: { hostname, network }
   };
 }
 
 export function flushSelectedHostname(network: Network): AnyAction {
   return {
     type: FLUSH_SELECTED_HOSTNAME,
-    payload: { network },
+    payload: { network }
   };
 }

--- a/src/application/redux/actions/connect.ts
+++ b/src/application/redux/actions/connect.ts
@@ -11,46 +11,46 @@ import {
   FLUSH_TX,
   SELECT_HOSTNAME,
   SET_MSG,
-  SET_TX_DATA
+  SET_TX_DATA,
 } from './action-types';
 
 export function enableWebsite(hostname: string, network: Network): AnyAction {
   return {
     type: ENABLE_WEBSITE,
-    payload: { hostname, network }
+    payload: { hostname, network },
   };
 }
 
 export function disableWebsite(hostname: string, network: Network): AnyAction {
   return {
     type: DISABLE_WEBSITE,
-    payload: { hostname, network }
+    payload: { hostname, network },
   };
 }
 
 export function setMsg(hostname: string, message: string): AnyAction {
   return {
     type: SET_MSG,
-    payload: { hostname, message }
+    payload: { hostname, message },
   };
 }
 
 export function flushMsg(): AnyAction {
   return {
-    type: FLUSH_MSG
+    type: FLUSH_MSG,
   };
 }
 
 export function flushTx(): AnyAction {
   return {
-    type: FLUSH_TX
+    type: FLUSH_TX,
   };
 }
 
 export function setTx(hostname: string, pset: string): AnyAction {
   return {
     type: SET_TX_DATA,
-    payload: { hostname, pset } as ConnectData['tx']
+    payload: { hostname, pset } as ConnectData['tx'],
   };
 }
 
@@ -63,20 +63,20 @@ export function setTxData(
 ): AnyAction {
   return {
     type: SET_TX_DATA,
-    payload: { hostname, recipients, feeAssetHash, network, data } as ConnectData['tx']
+    payload: { hostname, recipients, feeAssetHash, network, data } as ConnectData['tx'],
   };
 }
 
 export function selectHostname(hostname: string, network: Network): AnyAction {
   return {
     type: SELECT_HOSTNAME,
-    payload: { hostname, network }
+    payload: { hostname, network },
   };
 }
 
 export function flushSelectedHostname(network: Network): AnyAction {
   return {
     type: FLUSH_SELECTED_HOSTNAME,
-    payload: { network }
+    payload: { network },
   };
 }

--- a/src/application/redux/actions/connect.ts
+++ b/src/application/redux/actions/connect.ts
@@ -1,3 +1,4 @@
+import { RecipientInterface } from 'ldk';
 import { AnyAction } from 'redux';
 import { ConnectData } from '../../../domain/connect';
 import { Network } from '../../../domain/network';
@@ -11,8 +12,6 @@ import {
   SET_MSG,
   SET_TX_DATA,
 } from './action-types';
-
-import { RecipientInterface } from 'ldk';
 
 export function enableWebsite(hostname: string, network: Network): AnyAction {
   return {
@@ -58,11 +57,12 @@ export function setTxData(
   hostname: string,
   recipients: RecipientInterface[],
   feeAssetHash: string,
-  network: Network
+  network: Network,
+  data: string[]
 ): AnyAction {
   return {
     type: SET_TX_DATA,
-    payload: { hostname, recipients, feeAssetHash, network } as ConnectData['tx'],
+    payload: { hostname, recipients, feeAssetHash, network, data } as ConnectData['tx'],
   };
 }
 

--- a/src/application/utils/transaction.ts
+++ b/src/application/utils/transaction.ts
@@ -16,7 +16,6 @@ import {
   TxInterface,
   UnblindedOutputInterface,
   UtxoInterface,
-  walletFromCoins
 } from 'ldk';
 import { confidential, networks, payments, Psbt } from 'liquidjs-lib';
 import { blindingKeyFromAddress, isConfidentialAddress, networkFromString } from './address';
@@ -96,7 +95,7 @@ export function createTaxiTxFromTopup(
     recipients.concat({
       value: taxiTopup.assetAmount,
       asset: taxiTopup.assetHash,
-      address: '' // address is not useful for coinSelector
+      address: '', // address is not useful for coinSelector
     }),
     changeAddressGetter
   );
@@ -200,7 +199,7 @@ export function toDisplayTransaction(
     fee: tx.fee,
     transfers,
     type: txTypeFromTransfer(transfers),
-    webExplorersBlinders: getUnblindURLFromTx(tx, '')
+    webExplorersBlinders: getUnblindURLFromTx(tx, ''),
   };
 }
 
@@ -266,7 +265,7 @@ function getTransfers(
 
     transfers.push({
       amount,
-      asset
+      asset,
     });
   };
 
@@ -337,7 +336,7 @@ function withDataOutputs(psetBase64: string, dataOutputs: DataRecipient[]) {
     pset.addOutput({
       script: opReturnPayment.output!,
       asset: recipient.asset,
-      value: confidential.satoshiToConfidentialValue(recipient.value)
+      value: confidential.satoshiToConfidentialValue(recipient.value),
     });
   }
 

--- a/src/content/marinaBroker.ts
+++ b/src/content/marinaBroker.ts
@@ -23,7 +23,7 @@ import {
   restorerOptsSelector,
   utxosSelector,
 } from '../application/redux/selectors/wallet.selector';
-import { masterPubKeyRestorerFromState, MasterPublicKey, RecipientInterface } from 'ldk';
+import { masterPubKeyRestorerFromState, MasterPublicKey } from 'ldk';
 import {
   incrementAddressIndex,
   incrementChangeAddressIndex,
@@ -32,7 +32,7 @@ import { lbtcAssetByNetwork, sortRecipients } from '../application/utils';
 import { walletTransactions } from '../application/redux/selectors/transaction.selector';
 import { balancesSelector } from '../application/redux/selectors/balance.selector';
 import { assetGetterFromIAssets } from '../domain/assets';
-import { Balance, isDataRecipient, Recipient } from 'marina-provider';
+import { Balance, Recipient } from 'marina-provider';
 import { SignTransactionPopupResponse } from '../presentation/connect/sign-tx';
 import { SpendPopupResponse } from '../presentation/connect/spend';
 import { SignMessagePopupResponse } from '../presentation/connect/sign-msg';

--- a/src/domain/connect.ts
+++ b/src/domain/connect.ts
@@ -22,8 +22,8 @@ export function newEmptyConnectData(): ConnectData {
   return {
     enabledSites: {
       liquid: [],
-      regtest: []
+      regtest: [],
     },
-    hostnameSelected: ''
+    hostnameSelected: '',
   };
 }

--- a/src/domain/connect.ts
+++ b/src/domain/connect.ts
@@ -9,6 +9,7 @@ export type ConnectData = {
     feeAssetHash?: string;
     hostname?: string;
     pset?: string;
+    data?: string[];
   };
   msg?: {
     hostname?: string;

--- a/src/domain/connect.ts
+++ b/src/domain/connect.ts
@@ -1,5 +1,6 @@
 import { Network } from './network';
 import { RecipientInterface } from 'ldk';
+import { DataRecipient } from 'marina-provider';
 
 export type ConnectData = {
   enabledSites: Record<Network, string[]>;
@@ -9,7 +10,7 @@ export type ConnectData = {
     feeAssetHash?: string;
     hostname?: string;
     pset?: string;
-    data?: string[];
+    data?: DataRecipient[];
   };
   msg?: {
     hostname?: string;
@@ -21,8 +22,8 @@ export function newEmptyConnectData(): ConnectData {
   return {
     enabledSites: {
       liquid: [],
-      regtest: [],
+      regtest: []
     },
-    hostnameSelected: '',
+    hostnameSelected: ''
   };
 }

--- a/src/presentation/components/address-amount-form.tsx
+++ b/src/presentation/components/address-amount-form.tsx
@@ -178,7 +178,6 @@ const AddressAmountEnhancedForm = withFormik<AddressAmountFormProps, AddressAmou
 
     props.history.push({
       pathname: SEND_CHOOSE_FEE_ROUTE,
-      state: { changeAddress: changeAddress },
     });
   },
   displayName: 'AddressAmountForm',

--- a/src/presentation/connect/spend.tsx
+++ b/src/presentation/connect/spend.tsx
@@ -7,7 +7,7 @@ import { debounce } from 'lodash';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   connectWithConnectData,
-  WithConnectDataProps
+  WithConnectDataProps,
 } from '../../application/redux/containers/with-connect-data.container';
 import { RootReducerState } from '../../domain/common';
 import type { AddressInterface, Mnemonic, RecipientInterface, UtxoInterface } from 'ldk';
@@ -20,7 +20,7 @@ import { blindAndSignPset, createSendPset } from '../../application/utils/transa
 import { incrementChangeAddressIndex } from '../../application/redux/actions/wallet';
 import {
   restorerOptsSelector,
-  utxosSelector
+  utxosSelector,
 } from '../../application/redux/selectors/wallet.selector';
 import { decrypt } from '../../application/utils/crypto';
 import PopupWindowProxy from './popupWindowProxy';

--- a/src/presentation/connect/spend.tsx
+++ b/src/presentation/connect/spend.tsx
@@ -7,7 +7,7 @@ import { debounce } from 'lodash';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   connectWithConnectData,
-  WithConnectDataProps,
+  WithConnectDataProps
 } from '../../application/redux/containers/with-connect-data.container';
 import { RootReducerState } from '../../domain/common';
 import type { AddressInterface, Mnemonic, RecipientInterface, UtxoInterface } from 'ldk';
@@ -16,15 +16,11 @@ import { flushTx } from '../../application/redux/actions/connect';
 import { Network } from '../../domain/network';
 import { ConnectData } from '../../domain/connect';
 import { mnemonicWallet } from '../../application/utils/restorer';
-import {
-  withDataOutputs,
-  blindAndSignPset,
-  createSendPset,
-} from '../../application/utils/transaction';
+import { blindAndSignPset, createSendPset } from '../../application/utils/transaction';
 import { incrementChangeAddressIndex } from '../../application/redux/actions/wallet';
 import {
   restorerOptsSelector,
-  utxosSelector,
+  utxosSelector
 } from '../../application/redux/selectors/wallet.selector';
 import { decrypt } from '../../application/utils/crypto';
 import PopupWindowProxy from './popupWindowProxy';
@@ -194,17 +190,14 @@ async function makeTransaction(
     return changeAddresses[asset].confidentialAddress;
   };
 
-  let unsignedPset = await createSendPset(
+  const unsignedPset = await createSendPset(
     recipients,
     coins,
     feeAssetHash,
     changeAddressGetter,
-    network
+    network,
+    data
   );
-
-  if (data && data.length > 0) {
-    unsignedPset = withDataOutputs(unsignedPset, data, network);
-  }
 
   const txHex = await blindAndSignPset(
     mnemonic,

--- a/src/presentation/wallet/send/choose-fee.tsx
+++ b/src/presentation/wallet/send/choose-fee.tsx
@@ -122,11 +122,17 @@ const ChooseFeeView: React.FC<ChooseFeeProps> = ({
     setFeeChange(undefined);
     const w = walletFromCoins(Object.values(wallet.utxoMap), network);
     const currentSatsPerByte = feeLevelToSatsPerByte[feeLevel];
+
+    if (!changeAddress) throw new Error('change address is not defined');
+    console.log(recipients);
+    console.log(changeAddress);
+    console.log(wallet.utxoMap);
+
     const tx: string = w.buildTx(
       w.createTx(),
       recipients,
       greedyCoinSelector(),
-      () => changeAddress?.value,
+      () => changeAddress.value,
       true,
       currentSatsPerByte
     );

--- a/src/presentation/wallet/send/choose-fee.tsx
+++ b/src/presentation/wallet/send/choose-fee.tsx
@@ -124,9 +124,6 @@ const ChooseFeeView: React.FC<ChooseFeeProps> = ({
     const currentSatsPerByte = feeLevelToSatsPerByte[feeLevel];
 
     if (!changeAddress) throw new Error('change address is not defined');
-    console.log(recipients);
-    console.log(changeAddress);
-    console.log(wallet.utxoMap);
 
     const tx: string = w.buildTx(
       w.createTx(),

--- a/test/_regtest.ts
+++ b/test/_regtest.ts
@@ -3,7 +3,7 @@
 /* eslint-disable no-constant-condition */
 import axios from 'axios';
 
-const APIURL = process.env.EXPLORER || `http://localhost:3001`;
+export const APIURL = process.env.EXPLORER || `http://localhost:3001`;
 
 export function sleep(ms: number): Promise<any> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/test/spend.spec.ts
+++ b/test/spend.spec.ts
@@ -1,0 +1,79 @@
+import { decodePset, fetchAndUnblindUtxos, Mnemonic, networks } from 'ldk';
+import { makeRandomMnemonic } from './test.utils';
+import { APIURL, broadcastTx, faucet } from './_regtest';
+import { blindAndSignPset, createSendPset } from '../src/application/utils/transaction';
+import { payments, Transaction } from 'liquidjs-lib';
+
+jest.setTimeout(15000);
+
+const network = networks.regtest;
+
+const RECEIVER = 'AzpofttCgtcfk1PDWytoocvMWqQnLUJfjZw6MVmSdJQtwWnovQPgqiWSRTFZmKub3BNEpLYkyrr4czSp';
+
+describe('create send pset (build, blind & sign)', () => {
+  const mnemonic: Mnemonic = makeRandomMnemonic();
+
+  const makeUnspents = async () => {
+    const addr = await mnemonic.getNextAddress();
+    await faucet(addr.confidentialAddress, 10000);
+    return fetchAndUnblindUtxos([addr], APIURL);
+  };
+
+  const makeChangeAddressGetter = async () => {
+    const addr = (await mnemonic.getNextChangeAddress()).confidentialAddress;
+    return () => addr;
+  };
+
+  const makeRecipients = (...args: Array<{ value: number }>) =>
+    args.map(({ value }) => ({
+      address: RECEIVER,
+      asset: network.assetHash,
+      value,
+    }));
+
+  const blindAndSign = (pset: string) => blindAndSignPset(mnemonic, pset, [RECEIVER]);
+
+  test('should be able to create a regular transaction', async () => {
+    const pset = await createSendPset(
+      makeRecipients({ value: 100 }, { value: 110 }),
+      await makeUnspents(),
+      network.assetHash,
+      await makeChangeAddressGetter(),
+      'regtest'
+    );
+
+    const decoded = decodePset(pset);
+    expect(decoded.data.outputs).toHaveLength(4); // recipients outputs (2) + fee output + change output
+    expect(decoded.data.inputs).toHaveLength(1); // should select the faucet unspent
+
+    const signed = await blindAndSign(pset);
+    await broadcastTx(signed);
+  });
+
+  test('should be able to create a transaction with OP_RETURN data', async () => {
+    const OP_RETURN_DATA = '6666666666666666';
+
+    const pset = await createSendPset(
+      makeRecipients({ value: 200 }),
+      await makeUnspents(),
+      network.assetHash,
+      await makeChangeAddressGetter(),
+      'regtest',
+      [{ data: OP_RETURN_DATA, value: 120, asset: network.assetHash }]
+    );
+
+    const decoded = decodePset(pset);
+    expect(decoded.data.outputs).toHaveLength(4); // recipient output + fee output + change output + OP_RETURN output
+    expect(decoded.data.inputs).toHaveLength(1); // should select the faucet unspent
+
+    const signed = await blindAndSign(pset);
+    const signedTx = Transaction.fromHex(signed);
+    const opReturnScript = payments
+      .embed({ data: [Buffer.from(OP_RETURN_DATA, 'hex')], network })
+      .output!.toString('hex');
+
+    expect(signedTx.outs.map((o) => o.script.toString('hex'))).toContain(opReturnScript);
+
+    await broadcastTx(signed);
+  });
+});

--- a/test/test.utils.ts
+++ b/test/test.utils.ts
@@ -1,0 +1,7 @@
+import { generateMnemonic } from 'bip39';
+import { IdentityType, Mnemonic } from 'ldk';
+
+export function makeRandomMnemonic(): Mnemonic {
+  const mnemo = generateMnemonic();
+  return new Mnemonic({ type: IdentityType.Mnemonic, chain: 'regtest', opts: { mnemonic: mnemo } });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6340,10 +6340,10 @@ marina-provider@^1.0.0:
   resolved "https://registry.yarnpkg.com/marina-provider/-/marina-provider-1.3.0.tgz#ee26222816570e5649457c5eb6f3078433af5cd8"
   integrity sha512-J00cMcynnNwLut8GdbLNHSHR7jKUGcaiJfExgomIDbIMXJD/nZZQlxg8/zzPsAnujMx/aAEqqfEj+h4PIohp9g==
 
-marina-provider@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/marina-provider/-/marina-provider-1.4.2.tgz#44ccc2aaee79c98d70d9ccf88b57dd275cfa929a"
-  integrity sha512-s+qjzy8pjtuPbAeeLZCUlZXb/aWgkVinlTs8VVyB7yUPI8OXCUAyO8q++LZdahU6s6aRw/yM3qH1MAGFkC6aKA==
+marina-provider@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/marina-provider/-/marina-provider-1.4.3.tgz#15e51c989569e96088a74916ff195e03fc0b05c8"
+  integrity sha512-FXeJ61q+arMUEdR7GeXLmT/Xx8w1NP5vmkztkBIeSmRFvs02qjJO6GqutEUnVFWUzC3QQSB45yiOo8+i8ohYZw==
 
 marky@^1.2.0:
   version "1.2.2"


### PR DESCRIPTION
* Implement the `data` argument in `sendTransaction` and handle `DataRecipient`: it lets to add an unconfidential OP_RETURN output.
* add `spend.spec.ts` file: test the `creastSendPset` flow mainly.
* use nigiri-github-action in GH CI workflow.

update to marina-provider 1.4.3 (https://github.com/vulpemventures/marina-provider/pull/9)

it closes #231 

@tiero please review