### PR TITLE
Fix connect popup routes

### DIFF
--- a/src/content/marinaBroker.ts
+++ b/src/content/marinaBroker.ts
@@ -33,7 +33,7 @@ import { walletTransactions } from '../application/redux/selectors/transaction.s
 import { balancesSelector } from '../application/redux/selectors/balance.selector';
 import { assetGetterFromIAssets } from '../domain/assets';
 import { Balance, Recipient } from 'marina-provider';
-import { SignTransactionPopupResponse } from '../presentation/connect/sign-tx';
+import { SignTransactionPopupResponse } from '../presentation/connect/sign-pset';
 import { SpendPopupResponse } from '../presentation/connect/spend';
 import { SignMessagePopupResponse } from '../presentation/connect/sign-msg';
 
@@ -147,10 +147,10 @@ export default class MarinaBroker extends Broker {
           if (!params || params.length !== 1) {
             throw new Error('Missing params');
           }
-          const [tx] = params;
-          await this.store.dispatchAsync(setTx(this.hostname, tx));
+          const [pset] = params;
+          await this.store.dispatchAsync(setTx(this.hostname, pset));
           const { accepted, signedPset } =
-            await this.openAndWaitPopup<SignTransactionPopupResponse>('sign-tx');
+            await this.openAndWaitPopup<SignTransactionPopupResponse>('sign-pset');
 
           await this.store.dispatchAsync(flushTx());
           if (!accepted) throw new Error('User rejected the sign request');

--- a/src/domain/message.ts
+++ b/src/domain/message.ts
@@ -14,10 +14,10 @@ export interface ResponseMessage {
 }
 
 // basically the name of the connect/* files
-export type PopupName = 'enable' | 'sign-msg' | 'sign-tx' | 'spend';
+export type PopupName = 'enable' | 'sign-msg' | 'sign-pset' | 'spend';
 
 export function isPopupName(name: any): name is PopupName {
-  return name === 'enable' || name === 'sign-msg' || name === 'sign-tx' || name === 'spend';
+  return name === 'enable' || name === 'sign-msg' || name === 'sign-pset' || name === 'spend';
 }
 
 export function isResponseMessage(message: unknown): message is ResponseMessage {

--- a/src/presentation/connect/sign-msg.tsx
+++ b/src/presentation/connect/sign-msg.tsx
@@ -90,7 +90,7 @@ const ConnectSignMsg: React.FC<WithConnectDataProps> = ({ connectData }) => {
   return (
     <ShellConnectPopup
       className="h-popupContent container pb-20 mx-auto text-center bg-bottom bg-no-repeat"
-      currentPage="Spend"
+      currentPage="Sign message"
     >
       {error.length === 0 ? (
         <>

--- a/src/presentation/connect/sign-pset.tsx
+++ b/src/presentation/connect/sign-pset.tsx
@@ -73,10 +73,11 @@ const ConnectSignTransaction: React.FC<WithConnectDataProps> = ({ connectData })
     debounce(signTx, 2000, { leading: true, trailing: false })
   ).current;
 
+  console.log(connectData.tx?.pset);
   return (
     <ShellConnectPopup
       className="h-popupContent container pb-20 mx-auto text-center bg-bottom bg-no-repeat"
-      currentPage="Spend"
+      currentPage="Sign PSET"
     >
       {error.length === 0 ? (
         <>

--- a/src/presentation/routes/constants.ts
+++ b/src/presentation/routes/constants.ts
@@ -1,8 +1,12 @@
+import { PopupName } from '../../domain/message';
+
 // Connect
-const CONNECT_ENABLE_ROUTE = '/connect/enable';
-const CONNECT_SPEND_ROUTE = '/connect/spend';
-const CONNECT_SPEND_PSET_ROUTE = '/connect/spend-pset';
-const CONNECT_SIGN_MSG_ROUTE = '/connect/sign-msg';
+const makeConnectRoute = (popupName: PopupName) => `/connect/${popupName}`;
+
+const CONNECT_ENABLE_ROUTE = makeConnectRoute('enable');
+const CONNECT_SPEND_ROUTE = makeConnectRoute('spend');
+const CONNECT_SIGN_PSET_ROUTE = makeConnectRoute('sign-pset');
+const CONNECT_SIGN_MSG_ROUTE = makeConnectRoute('sign-msg');
 
 // Onboarding
 const INITIALIZE_WELCOME_ROUTE = '/initialize/welcome';
@@ -50,7 +54,7 @@ export {
   //Connect
   CONNECT_ENABLE_ROUTE,
   CONNECT_SPEND_ROUTE,
-  CONNECT_SPEND_PSET_ROUTE,
+  CONNECT_SIGN_PSET_ROUTE,
   CONNECT_SIGN_MSG_ROUTE,
   // Onboarding
   INITIALIZE_WELCOME_ROUTE,

--- a/src/presentation/routes/index.tsx
+++ b/src/presentation/routes/index.tsx
@@ -4,7 +4,7 @@ import { ProtectedRoute } from './guards';
 import {
   CONNECT_ENABLE_ROUTE,
   CONNECT_SPEND_ROUTE,
-  CONNECT_SPEND_PSET_ROUTE,
+  CONNECT_SIGN_PSET_ROUTE,
   CONNECT_SIGN_MSG_ROUTE,
   INITIALIZE_WELCOME_ROUTE,
   INITIALIZE_SELECT_ACTION_ROUTE,
@@ -42,7 +42,7 @@ import {
 // Connect
 import ConnectEnableView from '../connect/enable';
 import ConnectSpend from '../connect/spend';
-import ConnectSignTransaction from '../connect/sign-tx';
+import ConnectSignTransaction from '../connect/sign-pset';
 import ConnectSignMsg from '../connect/sign-msg';
 
 // Onboarding
@@ -121,7 +121,7 @@ const Routes: React.FC = () => {
       {/*Connect*/}
       <Route exact path={CONNECT_ENABLE_ROUTE} component={ConnectEnableView} />
       <Route exact path={CONNECT_SPEND_ROUTE} component={ConnectSpend} />
-      <Route exact path={CONNECT_SPEND_PSET_ROUTE} component={ConnectSignTransaction} />
+      <Route exact path={CONNECT_SIGN_PSET_ROUTE} component={ConnectSignTransaction} />
       <Route exact path={CONNECT_SIGN_MSG_ROUTE} component={ConnectSignMsg} />
     </Switch>
   );


### PR DESCRIPTION
This PR fixes `sign-pset` popup route (error in name). To avoid making the same mistake later, popup routes are computed via the PopupName type using a new function: `const makeConnectRoute = (popupName: PopupName) => '/connect/${popupName}'`;.

it closes #234 

@tiero please review