### PR TITLE
Settings fixes

### DIFF
--- a/src/presentation/settings/change-password.tsx
+++ b/src/presentation/settings/change-password.tsx
@@ -30,7 +30,7 @@ const SettingsChangePasswordForm = (props: FormikProps<SettingsChangePasswordFor
       <Input
         name="currentPassword"
         placeholder="Enter current password"
-        title="Create password"
+        title="Current password"
         type="password"
         {...props}
       />

--- a/src/presentation/settings/deep-restorer.tsx
+++ b/src/presentation/settings/deep-restorer.tsx
@@ -29,7 +29,7 @@ const SettingsDeepRestorerView: React.FC<DeepRestorerProps> = ({
       btnDisabled={restorationLoading}
       backgroundImagePath="/assets/images/popup/bg-sm.png"
       className="h-popupContent container pb-20 mx-auto text-center bg-bottom bg-no-repeat"
-      currentPage="Networks"
+      currentPage="Deep restorer"
     >
       <p className="font-regular my-8 text-base text-left">Select the restoration gap limit</p>
       <Select

--- a/src/presentation/settings/explorer.tsx
+++ b/src/presentation/settings/explorer.tsx
@@ -69,7 +69,7 @@ const SettingsExplorer: React.FC = () => {
       className="h-popupContent container pb-20 mx-auto text-center bg-bottom bg-no-repeat"
       currentPage="Explorer"
     >
-      <p className="font-sm mt-8 text-left">Select the explorer</p>
+      <p className="font-regular my-8 text-base text-left">Select the explorer</p>
       <Select
         onClick={() => setCustom(false)}
         list={explorerTypesForNetwork(network)}


### PR DESCRIPTION
Some minor fixes on settings pages:

- fixes wrong input label on change password view
- fixes wrong "current page" on deep restorer
- adds same css classes as other subtitles in explorer selector view for coherence

@tiero please review