### PR TITLE
window proxy listener: handle undefined case

### DIFF
--- a/src/inject/proxy.ts
+++ b/src/inject/proxy.ts
@@ -9,9 +9,10 @@ export default class WindowProxy {
       window.addEventListener(
         id,
         (event: Event) => {
+          if (!(event instanceof Event)) return reject(new Error('invalid event'));
           const response = parse((event as CustomEvent).detail);
 
-          if (!response.success) return reject(new Error(response.error));
+          if (!response.success) return reject(new Error(response?.error ?? 'unknown error'));
           return resolve(response.data);
         },
         {


### PR DESCRIPTION
This PR checks if the event received in the proxy is an instance of `Event`. It also reject if undefined.

@tiero please review

