### PR TITLE
Many recipients

### DIFF
--- a/src/presentation/connect/spend.tsx
+++ b/src/presentation/connect/spend.tsx
@@ -131,7 +131,7 @@ const ConnectSpend: React.FC<WithConnectDataProps> = ({ connectData }) => {
             </div>
           ))}
 
-          <div className="bottom-24 container absolute right-0 flex justify-between">
+          <div className="bottom-12 container absolute right-0 flex justify-between">
             <Button isOutline={true} onClick={handleReject} textBase={true}>
               Reject
             </Button>

--- a/src/presentation/connect/spend.tsx
+++ b/src/presentation/connect/spend.tsx
@@ -115,21 +115,23 @@ const ConnectSpend: React.FC<WithConnectDataProps> = ({ connectData }) => {
 
           <p className="mt-4 text-base font-medium">Requests you to spend</p>
 
-          {connectData.tx?.recipients?.map((recipient: RecipientInterface, index) => (
-            <div key={index}>
-              <div className="container flex justify-between mt-16">
-                <span className="text-lg font-medium">{recipient.value}</span>
-                <span className="text-lg font-medium">{getTicker(recipient.asset)}</span>
-              </div>
+          <div className="h-64 mt-4 overflow-y-auto">
+            {connectData.tx?.recipients?.map((recipient: RecipientInterface, index) => (
+              <div key={index}>
+                <div className="container flex justify-between mt-6">
+                  <span className="text-lg font-medium">{recipient.value}</span>
+                  <span className="text-lg font-medium">{getTicker(recipient.asset)}</span>
+                </div>
 
-              <div className="container flex items-baseline justify-between mt-4">
-                <span className="mr-2 text-lg font-medium">To: </span>
-                <span className="font-small text-sm break-all">
-                  {formatAddress(recipient.address)}
-                </span>
+                <div className="container flex items-baseline justify-between">
+                  <span className="mr-2 text-lg font-medium">To: </span>
+                  <span className="font-small text-sm break-all">
+                    {formatAddress(recipient.address)}
+                  </span>
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
 
           <div className="bottom-12 container absolute right-0 flex justify-between">
             <Button isOutline={true} onClick={handleReject} textBase={true}>

--- a/src/presentation/connect/spend.tsx
+++ b/src/presentation/connect/spend.tsx
@@ -122,7 +122,6 @@ const ConnectSpend: React.FC<WithConnectDataProps> = ({ connectData }) => {
                   <span className="text-lg font-medium">{recipient.value}</span>
                   <span className="text-lg font-medium">{getTicker(recipient.asset)}</span>
                 </div>
-
                 <div className="container flex items-baseline justify-between">
                   <span className="mr-2 text-lg font-medium">To: </span>
                   <span className="font-small text-sm break-all">


### PR DESCRIPTION
Fixes #256 

Supports up to 3 recipients without overflowing.

With 4 or more recipients it overflows on the y axis (adds scroll bar), see video:

https://user-images.githubusercontent.com/9318412/147461982-5f5e61af-d7a5-4804-9dfc-d383aaf0b10c.mov

How to test: go to https://demo.bitmatrix.app/swap and connect wallet.

@tiero please review
