### PR TITLE
[Hotfix] safe incrementation of address indexes + show default LBTC balance if needed

### DIFF
--- a/src/application/redux/reducers/wallet-reducer.ts
+++ b/src/application/redux/reducers/wallet-reducer.ts
@@ -51,7 +51,7 @@ export function walletReducer(
         ...state,
         restorerOpts: {
           ...state.restorerOpts,
-          lastUsedInternalIndex: increment(state.restorerOpts.lastUsedInternalIndex)
+          lastUsedInternalIndex: increment(state.restorerOpts.lastUsedInternalIndex),
         },
       };
     }
@@ -61,7 +61,7 @@ export function walletReducer(
         ...state,
         restorerOpts: {
           ...state.restorerOpts,
-          lastUsedExternalIndex: increment(state.restorerOpts.lastUsedExternalIndex)
+          lastUsedExternalIndex: increment(state.restorerOpts.lastUsedExternalIndex),
         },
       };
     }
@@ -142,4 +142,4 @@ const increment = (n: number | undefined): number => {
   if (n === undefined || n === null) return 0;
   if (n < 0) return 1; // -Infinity = 0, return 0+1=1
   return n + 1;
-}
+};

--- a/src/application/redux/reducers/wallet-reducer.ts
+++ b/src/application/redux/reducers/wallet-reducer.ts
@@ -51,9 +51,7 @@ export function walletReducer(
         ...state,
         restorerOpts: {
           ...state.restorerOpts,
-          lastUsedInternalIndex: state.restorerOpts.lastUsedInternalIndex
-            ? state.restorerOpts.lastUsedInternalIndex + 1
-            : 0,
+          lastUsedInternalIndex: increment(state.restorerOpts.lastUsedInternalIndex)
         },
       };
     }
@@ -63,9 +61,7 @@ export function walletReducer(
         ...state,
         restorerOpts: {
           ...state.restorerOpts,
-          lastUsedExternalIndex: state.restorerOpts.lastUsedExternalIndex
-            ? state.restorerOpts.lastUsedExternalIndex + 1
-            : 0,
+          lastUsedExternalIndex: increment(state.restorerOpts.lastUsedExternalIndex)
         },
       };
     }
@@ -140,4 +136,10 @@ export function walletReducer(
       return state;
     }
   }
+}
+
+const increment = (n: number | undefined): number => {
+  if (n === undefined || n === null) return 0;
+  if (n < 0) return 1; // -Infinity = 0, return 0+1=1
+  return n + 1;
 }

--- a/src/application/redux/selectors/balance.selector.ts
+++ b/src/application/redux/selectors/balance.selector.ts
@@ -1,5 +1,6 @@
 import { balances } from 'ldk';
 import { RootReducerState } from '../../../domain/common';
+import { lbtcAssetByNetwork } from '../../utils';
 
 export type BalancesByAsset = { [assetHash: string]: number };
 /**
@@ -9,5 +10,12 @@ export type BalancesByAsset = { [assetHash: string]: number };
  */
 export function balancesSelector(state: RootReducerState): BalancesByAsset {
   const utxos = Object.values(state.wallet.utxoMap);
-  return balances(utxos);
+  const balancesFromUtxos = balances(utxos);
+
+  const lbtcAssetHash = lbtcAssetByNetwork(state.app.network);
+  if (balancesFromUtxos[lbtcAssetHash] === undefined) {
+    balancesFromUtxos[lbtcAssetHash] = 0;
+  }
+
+  return balancesFromUtxos;
 }

--- a/src/application/redux/selectors/balance.selector.ts
+++ b/src/application/redux/selectors/balance.selector.ts
@@ -13,7 +13,7 @@ export function balancesSelector(state: RootReducerState): BalancesByAsset {
   const balancesFromUtxos = balances(utxos);
 
   const lbtcAssetHash = lbtcAssetByNetwork(state.app.network);
-  if (balancesFromUtxos[lbtcAssetHash] === undefined) {
+  if (!Object.prototype.hasOwnProperty.call(balancesFromUtxos, lbtcAssetHash)) {
     balancesFromUtxos[lbtcAssetHash] = 0;
   }
 


### PR DESCRIPTION
This PR fixes two regressions:
1. on a new wallet, the first address is now correctly persisted (it closes #263)
2. if a wallet doesn't own any LBTC, a default balance is now added (LBTC = 0)

@tiero @bordalix please review