### PR TITLE
Fix webpack performance in dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "NETWORK=regtest webpack --watch --config webpack.dev.js",
-    "build": "webpack --config webpack.prod.js",
+    "build": "NODE_ENV=production webpack --config webpack.prod.js",
     "clean": "rimraf dist",
     "lint": "eslint --ext .ts,.tsx src test",
     "lint:fix": "eslint --fix --ext .ts,.tsx src test",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,7 @@ const colors = require('tailwindcss/colors');
 module.exports = {
   // TODO: PostCSS plugin postcss-purgecss requires PostCSS 8
   purge: {
-    enabled: true,
+    enabled: process.env.NODE_ENV === 'production',
     content: [
         './**/*.html',
         './**/*.tsx',


### PR DESCRIPTION
Webpack in dev was taking me almost 3 minutes between incremental builds.
I've found the culprit, it was purging the CSS.
This PR makes purge only work on production build.
Webpack incremental builds in dev are now back to under 2 seconds.

@tiero please review