### PR TITLE
Start periodic updater at background startup

### DIFF
--- a/src/background/background-script.ts
+++ b/src/background/background-script.ts
@@ -1,7 +1,7 @@
 import SafeEventEmitter from '@metamask/safe-event-emitter';
 import browser from 'webextension-polyfill';
 import { testWalletData } from '../application/constants/cypress';
-import { logOut, onboardingCompleted } from '../application/redux/actions/app';
+import { logOut, onboardingCompleted, startPeriodicUpdate } from '../application/redux/actions/app';
 import { enableWebsite } from '../application/redux/actions/connect';
 import { setWalletData } from '../application/redux/actions/wallet';
 import { marinaStore, wrapMarinaStore } from '../application/redux/store';
@@ -55,6 +55,8 @@ browser.runtime.onStartup.addListener(() => {
     if (marinaStore.getState().wallet.encryptedMnemonic !== '') {
       // Everytime the browser starts up we need to set up the popup page
       await browser.browserAction.setPopup({ popup: 'popup.html' });
+      // We also set up the periodic update if the user is onboarded
+      marinaStore.dispatch(startPeriodicUpdate());
     }
   })().catch(console.error);
 });

--- a/src/presentation/connect/sign-pset.tsx
+++ b/src/presentation/connect/sign-pset.tsx
@@ -74,7 +74,6 @@ const ConnectSignTransaction: React.FC<WithConnectDataProps> = ({ connectData })
     debounce(signTx, 2000, { leading: true, trailing: false })
   ).current;
 
-  console.log(connectData.tx?.pset);
   return (
     <ShellConnectPopup
       className="h-popupContent container pb-20 mx-auto text-center bg-bottom bg-no-repeat"

--- a/src/presentation/wallet/log-in/index.tsx
+++ b/src/presentation/wallet/log-in/index.tsx
@@ -6,7 +6,7 @@ import { DEFAULT_ROUTE, INITIALIZE_WELCOME_ROUTE } from '../../routes/constants'
 import Button from '../../components/button';
 import Input from '../../components/input';
 import { useDispatch, useSelector } from 'react-redux';
-import { logIn, startPeriodicUpdate } from '../../../application/redux/actions/app';
+import { logIn } from '../../../application/redux/actions/app';
 import { setIdleAction } from '../../../application/utils';
 import {
   AUTHENTICATION_SUCCESS,
@@ -76,7 +76,6 @@ const LogInEnhancedForm = withFormik<LogInFormProps, LogInFormValues>({
       .then(() => {
         if (logInAction.type === AUTHENTICATION_SUCCESS) {
           props.dispatch(updateTaxiAssets()).catch(console.error);
-          props.dispatch(startPeriodicUpdate()).catch(console.error);
           props.history.push(DEFAULT_ROUTE);
           setIdleAction(() => {
             props.dispatch({ type: LOGOUT_SUCCESS }).catch(console.error);


### PR DESCRIPTION
This PR moves the startPeriodicUpdater action from the login page to the background startup listener.

It means that the periodic updater is now launched each time the marina background is started (= each time we open the browser). Note that we do not launch the updater if the user is not onboarded.

it closes #275 

@tiero please review