### PR TITLE
Fixes back from Receive

### DIFF
--- a/src/application/redux/containers/transactions.container.ts
+++ b/src/application/redux/containers/transactions.container.ts
@@ -8,6 +8,7 @@ const mapStateToProps = (state: RootReducerState): TransactionsProps => ({
   assets: state.assets,
   transactions: walletTransactions(state),
   webExplorerURL: selectElectrsURL(state),
+  isWalletVerified: state.wallet.isVerified,
 });
 
 const Transactions = connect(mapStateToProps)(TransactionsView);

--- a/src/presentation/wallet/receive/index.tsx
+++ b/src/presentation/wallet/receive/index.tsx
@@ -9,6 +9,7 @@ import { updateUtxos } from '../../../application/redux/actions/utxos';
 import { ProxyStoreDispatch } from '../../../application/redux/proxyStore';
 import { masterPubKeyRestorerFromState, MasterPublicKey, StateRestorerOpts } from 'ldk';
 import { incrementAddressIndex } from '../../../application/redux/actions/wallet';
+import { DEFAULT_ROUTE } from '../../routes/constants';
 
 export interface ReceiveProps {
   pubKey: MasterPublicKey;
@@ -23,7 +24,7 @@ const ReceiveView: React.FC<ReceiveProps> = ({ pubKey, restorerOpts }) => {
   const [buttonText, setButtonText] = useState('Copy');
   const [isAddressExpanded, setAddressExpanded] = useState(false);
   const handleExpand = () => setAddressExpanded(true);
-  const handleBackBtn = () => history.goBack();
+  const handleBackBtn = () => history.push(DEFAULT_ROUTE);
   const handleCopy = () => {
     navigator.clipboard.writeText(confidentialAddress).then(
       () => setButtonText('Copied'),

--- a/src/presentation/wallet/receive/index.tsx
+++ b/src/presentation/wallet/receive/index.tsx
@@ -24,7 +24,7 @@ const ReceiveView: React.FC<ReceiveProps> = ({ pubKey, restorerOpts }) => {
   const [buttonText, setButtonText] = useState('Copy');
   const [isAddressExpanded, setAddressExpanded] = useState(false);
   const handleExpand = () => setAddressExpanded(true);
-  const handleBackBtn = () => history.push(DEFAULT_ROUTE);
+  const handleBackBtn = () => history.replace(DEFAULT_ROUTE);
   const handleCopy = () => {
     navigator.clipboard.writeText(confidentialAddress).then(
       () => setButtonText('Copied'),

--- a/src/presentation/wallet/transactions/index.tsx
+++ b/src/presentation/wallet/transactions/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import browser from 'webextension-polyfill';
 import {
+  BACKUP_UNLOCK_ROUTE,
   DEFAULT_ROUTE,
   RECEIVE_ADDRESS_ROUTE,
   SEND_ADDRESS_AMOUNT_ROUTE,
@@ -35,12 +36,14 @@ export interface TransactionsProps {
   assets: IAssets;
   transactions: TxDisplayInterface[];
   webExplorerURL: string;
+  isWalletVerified: boolean;
 }
 
 const TransactionsView: React.FC<TransactionsProps> = ({
   assets,
   transactions,
   webExplorerURL,
+  isWalletVerified,
 }) => {
   const history = useHistory();
   const { state } = useLocation<LocationState>();
@@ -53,8 +56,16 @@ const TransactionsView: React.FC<TransactionsProps> = ({
   // Save mnemonic modal
   const [isSaveMnemonicModalOpen, showSaveMnemonicModal] = useState(false);
   const handleSaveMnemonicClose = () => showSaveMnemonicModal(false);
-  const handleSaveMnemonicConfirm = () => history.push(RECEIVE_ADDRESS_ROUTE);
-  const handleReceive = () => showSaveMnemonicModal(true);
+  const handleSaveMnemonicConfirm = async () => {
+    await browser.tabs.create({ url: `home.html#${BACKUP_UNLOCK_ROUTE}` });
+  };
+  const handleReceive = () => {
+    if (!isWalletVerified) {
+      showSaveMnemonicModal(true);
+    } else {
+      history.push(RECEIVE_ADDRESS_ROUTE);
+    }
+  };
   const handleSend = async () => {
     await dispatch(setAsset(state.assetHash));
     history.push(SEND_ADDRESS_AMOUNT_ROUTE);


### PR DESCRIPTION
Fixes #277

This PR fixes two issues:
1. When going back from Receive the app would crash (see #277 for details)
2. When clicking on Receive from the Asset view the app would always say the mnemonic was not saved
3. Clicking save on the Save Mnemonic modal from step 2 would proceed to Address view

isWalletVerified is now passed as props to Transactions view.

@tiero please review