### PR TITLE
Fix first click on the extension after install

### DIFF
--- a/src/background/background-script.ts
+++ b/src/background/background-script.ts
@@ -78,7 +78,7 @@ browser.browserAction.onClicked.addListener(() => {
       return;
     } else {
       await browser.browserAction.setPopup({ popup: 'popup.html' });
-      await browser.browserAction.openPopup();
+      if (browser.browserAction.openPopup) await browser.browserAction.openPopup();
     }
   })().catch(console.error);
 });


### PR DESCRIPTION
Fix first click on the extension after install would generate a console error:
- browser.browserAction.openPopup() is only supported on Firefox

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/openPopup

@tiero please review