### PR TITLE
Rest in taxi

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,5 +10,4 @@ module.exports = {
   transform: {
     '.+\\.ts$': 'ts-jest',
   },
-  transformIgnorePatterns: ['node_modules/(?!(taxi-protobuf)/)"'],
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "crypto-browserify": "^3.12.0",
     "decimal.js": "^10.2.1",
     "formik": "^2.2.6",
-    "google-protobuf": "^3.15.8",
     "ldk": "^0.4.0",
     "lodash.debounce": "^4.0.8",
     "lottie-web": "^5.7.8",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "redux-thunk": "^2.3.0",
     "stream-browserify": "^3.0.0",
     "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.2",
-    "taxi-protobuf": "vulpemventures/taxi-protobuf",
     "uuid": "^8.3.2",
     "webext-redux": "^2.1.7",
     "webextension-polyfill": "^0.8.0",

--- a/src/application/utils/constants.ts
+++ b/src/application/utils/constants.ts
@@ -12,13 +12,8 @@ export const feeLevelToSatsPerByte: { [key: string]: number } = {
 
 export const taxiURL: Record<NetworkString, string> = {
   regtest: 'http://localhost:8000',
-<<<<<<< HEAD
   testnet: 'https://grpc.liquid.taxi:18000/v1',
   liquid: 'https://grpc.liquid.taxi/v1',
-=======
-  testnet: 'https://grpc.liquid.taxi:18000',
-  liquid: 'https://grpc.liquid.taxi',
->>>>>>> master
 };
 
 const makeImagePath = (fileName: string): string => `assets/images/liquid-assets/${fileName}`;

--- a/src/application/utils/constants.ts
+++ b/src/application/utils/constants.ts
@@ -12,8 +12,8 @@ export const feeLevelToSatsPerByte: { [key: string]: number } = {
 
 export const taxiURL: Record<NetworkString, string> = {
   regtest: 'http://localhost:8000',
-  testnet: 'http://todo.com', // TODO is there a taxi running on testnet ?
-  liquid: 'https://grpc.liquid.taxi',
+  testnet: 'https://grpc.liquid.taxi:18000/v1',
+  liquid: 'https://grpc.liquid.taxi/v1',
 };
 
 const makeImagePath = (fileName: string): string => `assets/images/liquid-assets/${fileName}`;

--- a/src/application/utils/network.ts
+++ b/src/application/utils/network.ts
@@ -5,8 +5,8 @@ import { IAssets } from '../../domain/assets';
 export const broadcastTx = async (baseUrl: string, txHex: string): Promise<string> => {
   const response = await axios.post(`${baseUrl}/tx`, txHex);
   if (response.status !== 200) {
-    console.error(response.data);
-    throw new Error(response.data);
+    console.error(response);
+    throw new Error(JSON.stringify(response));
   }
   return response.data;
 };

--- a/src/application/utils/taxi.ts
+++ b/src/application/utils/taxi.ts
@@ -1,24 +1,24 @@
 import axios from 'axios';
 
 interface AssetDetails {
-  assetHash: string,
-  assetPrice: number,
-  basisPoint: number,
+  assetHash: string;
+  assetPrice: number;
+  basisPoint: number;
 }
 
 export interface Topup {
-  assetAmount: number,
-  assetHash: string,
-  assetSpread: number,
-  partial: string,
-  topupId: string,
+  assetAmount: number;
+  assetHash: string;
+  assetSpread: number;
+  partial: string;
+  topupId: string;
 }
 
 export interface TopupWithAssetReply {
-  expiry: number,
-  privateBlindingKey: string,
-  publicBlindingKey: string,
-  topup?: Topup,
+  expiry: number;
+  privateBlindingKey: string;
+  publicBlindingKey: string;
+  topup?: Topup;
 }
 
 export const fetchAssetsFromTaxi = async (taxiUrl: string): Promise<string[]> => {

--- a/src/application/utils/taxi.ts
+++ b/src/application/utils/taxi.ts
@@ -1,24 +1,35 @@
-import { TaxiClient } from 'taxi-protobuf/generated/js/TaxiServiceClientPb';
-import {
-  AssetDetails,
-  ListAssetsRequest,
-  TopupWithAssetReply,
-  TopupWithAssetRequest,
-} from 'taxi-protobuf/generated/js/taxi_pb';
+import axios from 'axios';
+
+interface AssetDetails {
+  assetHash: string,
+  basisPoint: number,
+  assetPrice: number,
+}
+
+export interface Topup {
+  topupId: string,
+  partial: string,
+  assetHash: string,
+  assetAmount: number,
+  assetSpread: number,
+}
+
+export interface TopupWithAssetReply {
+  topup?: Topup,
+  expiry: number,
+  privateBlindingKey: string,
+  publicBlindingKey: string,
+}
 
 export const fetchAssetsFromTaxi = async (taxiUrl: string): Promise<string[]> => {
-  const client = new TaxiClient(taxiUrl, undefined);
-  const res = await client.listAssets(new ListAssetsRequest(), null);
-  return res.getAssetsList().map((asset: AssetDetails) => asset.getAssetHash());
+  const { data } = await axios.get(`${taxiUrl}/assets`);
+  return data.assets.map((asset: AssetDetails) => asset.assetHash);
 };
 
 export const fetchTopupFromTaxi = async (
   taxiUrl: string,
-  asset: string
-): Promise<TopupWithAssetReply.AsObject> => {
-  const client = new TaxiClient(taxiUrl, undefined);
-  const request = new TopupWithAssetRequest();
-  request.setAssetHash(asset);
-  const res = await client.topupWithAsset(request, null);
-  return res.toObject();
+  assetHash: string
+): Promise<TopupWithAssetReply> => {
+  const { data } = await axios.post(`${taxiUrl}/asset/topup`, { assetHash });
+  return data;
 };

--- a/src/application/utils/taxi.ts
+++ b/src/application/utils/taxi.ts
@@ -30,6 +30,6 @@ export const fetchTopupFromTaxi = async (
   taxiUrl: string,
   assetHash: string
 ): Promise<TopupWithAssetReply> => {
-  const { data } = await axios.post(`${taxiUrl}/asset/topup`, { assetHash });
+  const { data } = await axios.post(`${taxiUrl}/asset/topup`, assetHash);
   return data;
 };

--- a/src/application/utils/taxi.ts
+++ b/src/application/utils/taxi.ts
@@ -2,23 +2,23 @@ import axios from 'axios';
 
 interface AssetDetails {
   assetHash: string,
-  basisPoint: number,
   assetPrice: number,
+  basisPoint: number,
 }
 
 export interface Topup {
-  topupId: string,
-  partial: string,
-  assetHash: string,
   assetAmount: number,
+  assetHash: string,
   assetSpread: number,
+  partial: string,
+  topupId: string,
 }
 
 export interface TopupWithAssetReply {
-  topup?: Topup,
   expiry: number,
   privateBlindingKey: string,
   publicBlindingKey: string,
+  topup?: Topup,
 }
 
 export const fetchAssetsFromTaxi = async (taxiUrl: string): Promise<string[]> => {

--- a/src/application/utils/taxi.ts
+++ b/src/application/utils/taxi.ts
@@ -30,6 +30,6 @@ export const fetchTopupFromTaxi = async (
   taxiUrl: string,
   assetHash: string
 ): Promise<TopupWithAssetReply> => {
-  const { data } = await axios.post(`${taxiUrl}/asset/topup`, assetHash);
+  const { data } = await axios.post(`${taxiUrl}/asset/topup`, { assetHash });
   return data;
 };

--- a/src/application/utils/transaction.ts
+++ b/src/application/utils/transaction.ts
@@ -21,9 +21,8 @@ import {
 import { confidential, networks, payments, Psbt } from 'liquidjs-lib';
 import { blindingKeyFromAddress, isConfidentialAddress } from './address';
 import { Transfer, TxDisplayInterface, TxStatusEnum, TxType } from '../../domain/transaction';
-import { Topup } from 'taxi-protobuf/generated/js/taxi_pb';
 import { lbtcAssetByNetwork } from './network';
-import { fetchTopupFromTaxi } from './taxi';
+import { fetchTopupFromTaxi, Topup } from './taxi';
 import { taxiURL } from './constants';
 import { DataRecipient, isAddressRecipient, isDataRecipient, Recipient } from 'marina-provider';
 
@@ -92,7 +91,7 @@ const throwErrorCoinSelector: CoinSelectorErrorFn = (
  * @param changeAddressGetter define the way we get change addresses (if needed).
  */
 export function createTaxiTxFromTopup(
-  taxiTopup: Topup.AsObject,
+  taxiTopup: Topup,
   unspents: UnblindedOutput[],
   recipients: RecipientInterface[],
   coinSelector: CoinSelector,

--- a/src/presentation/wallet/send/choose-fee.tsx
+++ b/src/presentation/wallet/send/choose-fee.tsx
@@ -35,7 +35,7 @@ import {
 } from '../../../application/redux/actions/transaction';
 import { ProxyStoreDispatch } from '../../../application/redux/proxyStore';
 import { Address, createAddress } from '../../../domain/address';
-import { Topup } from 'taxi-protobuf/generated/js/taxi_pb';
+import { Topup } from '../../../application/utils/taxi';
 import { incrementChangeAddressIndex } from '../../../application/redux/actions/wallet';
 
 export interface ChooseFeeProps {
@@ -76,7 +76,7 @@ const ChooseFeeView: React.FC<ChooseFeeProps> = ({
   const [errorMessage, setErrorMessage] = useState<string>();
   const [loading, setLoading] = useState(false);
   const [feeChange, setFeeChange] = useState<Address>();
-  const [topup, setTopup] = useState<Topup.AsObject>();
+  const [topup, setTopup] = useState<Topup>();
 
   const circleLoaderRef = React.useRef(null);
   useLottieLoader(circleLoaderRef, '/assets/animations/circle-loader.json');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4497,11 +4497,6 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-google-protobuf@^3.15.8:
-  version "3.17.3"
-  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.17.3.tgz#f87595073545a77946c8f0b67c302c5f7646d700"
-  integrity sha512-OVPzcSWIAJ+d5yiHyeaLrdufQtrvaBrF4JQg+z8ynTkbO3uFcujqXszTumqg1cGsAsjkWnI+M5B1xZ19yR4Wyg==
-
 got@^9.6.0:
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4534,11 +4534,6 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-grpc-web@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/grpc-web/-/grpc-web-1.2.0.tgz#96402a1245ea834fedb1dd5a80f910476ddbbb1c"
-  integrity sha512-QS0RF+xiWnMEiHWyA0A0I8JYYJLOiF/DGEpRQ7vJDOzEZYfmNqI7d7d29sYBbNfTi+arVh2JpeGIX7ch24a+tA==
-
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
@@ -8840,12 +8835,6 @@ tapable@^2.1.1, tapable@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
   integrity sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==
-
-taxi-protobuf@vulpemventures/taxi-protobuf:
-  version "1.0.0"
-  resolved "https://codeload.github.com/vulpemventures/taxi-protobuf/tar.gz/43fad1d83547a9fb340147e622673b36b1e63b25"
-  dependencies:
-    grpc-web "1.2.0"
 
 terminal-link@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
Fixes #290 

Access taxi services via REST (removes gRPC).
Remove `taxi-protobuf` dependency.
Throw response (and not response.data) on broadcastTx.

@tiero please review
