### PR TITLE
fix overflow of balance (more then 1 line) cutting the last element f…

### DIFF
--- a/src/presentation/components/balance.tsx
+++ b/src/presentation/components/balance.tsx
@@ -39,7 +39,7 @@ const Balance: React.FC<Props> = ({
       />
       <div>
         <p
-          className={cx('text-grayDark  font-medium', {
+          className={cx('text-grayDark font-medium max-h-10', {
             'text-3xl': bigBalanceText,
             'text-lg': !bigBalanceText,
           })}


### PR DESCRIPTION
Fixes #294

Overflow of balance (with more than 1 line) was cutting the last element from the list of assets.

This commit defines a max-height of 40px to the balance paragraph.

@tiero please review.
