### PR TITLE
Unconfidential address 301

### DIFF
--- a/src/domain/address.ts
+++ b/src/domain/address.ts
@@ -12,21 +12,21 @@ export function createAddress(
   address: Address['value'],
   derivationPath?: Address['derivationPath']
 ): Address {
-  // Non Confidential
-  if (address.startsWith('ert') || address.startsWith('ex')) {
-    addressLDK.fromBech32(address);
-    return {
-      derivationPath: derivationPath,
-      value: address,
-    };
-  } else {
-    // Confidential
+  try {
+    // confidential address
     const { blindingKey, unconfidentialAddress } = addressLDK.fromConfidential(address);
     return {
       value: address,
       blindingKey: blindingKey,
       derivationPath: derivationPath,
       unconfidentialAddress: unconfidentialAddress,
+    };
+  } catch (ignore) {
+    // unconfidential address
+    addressLDK.fromBech32(address);
+    return {
+      derivationPath: derivationPath,
+      value: address,
     };
   }
 }


### PR DESCRIPTION
Fixes #301 

This PR:
- Implements a better way to detect if an address is or not confidential
- Adds test for sending a transaction with an unconfidential address

@tiero please review