### PR TITLE
Fix input blinding data

### DIFF
--- a/src/application/utils/transaction.ts
+++ b/src/application/utils/transaction.ts
@@ -18,6 +18,7 @@ import {
   getAsset,
   NetworkString,
   IdentityInterface,
+  isConfidentialOutput,
 } from 'ldk';
 import { confidential, networks, payments, Psbt } from 'liquidjs-lib';
 import { isConfidentialAddress } from './address';
@@ -64,10 +65,9 @@ function inputBlindingDataMap(
     index++;
     const utxo = utxos.find((u) => txidToBuffer(u.txid).equals(input.hash));
 
-    // if the input is confidential, unblindData will be defined
-    // in that case, we need to add it to the blinding data map
+    // if the input is confidential we need to add it to the blinding data map
     // this let to ignore unconfidential inputs
-    if (utxo?.unblindData) {
+    if (utxo && isConfidentialOutput(utxo.prevout)) {
       inputBlindingData.set(index, utxo.unblindData);
     }
   }

--- a/src/application/utils/transaction.ts
+++ b/src/application/utils/transaction.ts
@@ -67,9 +67,8 @@ function inputBlindingDataMap(
       (u) => txidToBuffer(u.txid).equals(input.hash) && u.vout === input.index
     );
 
-    // if the input is confidential we need to add it to the blinding data map
-    // this let to ignore unconfidential inputs
-    if (utxo && isConfidentialOutput(utxo.prevout)) {
+    // only add unblind data if the prevout of the input is confidential
+    if (utxo && utxo.unblindData && isConfidentialOutput(utxo.prevout)) {
       inputBlindingData.set(index, utxo.unblindData);
     }
   }

--- a/src/application/utils/transaction.ts
+++ b/src/application/utils/transaction.ts
@@ -63,7 +63,9 @@ function inputBlindingDataMap(
   let index = -1;
   for (const input of psetToUnsignedTx(pset).ins) {
     index++;
-    const utxo = utxos.find((u) => txidToBuffer(u.txid).equals(input.hash));
+    const utxo = utxos.find(
+      (u) => txidToBuffer(u.txid).equals(input.hash) && u.vout === input.index
+    );
 
     // if the input is confidential we need to add it to the blinding data map
     // this let to ignore unconfidential inputs


### PR DESCRIPTION
This PR:

- fixes error detecting if an input is confidential (unblindData is defined in all inputs after all)
- fixes error that occurred when two inputs were from the same Tx (but with different vouts)

@louisinger @tiero please review