### PR TITLE
Return txid and hex in send transaction 310

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ldk": "0.4.4",
     "lodash.debounce": "^4.0.8",
     "lottie-web": "^5.7.8",
-    "marina-provider": "^1.4.7",
+    "marina-provider": "^1.4.8",
     "moment": "^2.29.1",
     "path-browserify": "^1.0.1",
     "postcss": "^7.0.35",

--- a/src/application/utils/network.ts
+++ b/src/application/utils/network.ts
@@ -3,8 +3,9 @@ import axios, { AxiosError } from 'axios';
 import { networks, NetworkString } from 'ldk';
 import { IAssets } from '../../domain/assets';
 import { extractErrorMessage } from '../../presentation/utils/error';
+import { TransactionID } from 'marina-provider';
 
-export const broadcastTx = async (baseUrl: string, txHex: string): Promise<string> => {
+export const broadcastTx = async (baseUrl: string, txHex: string): Promise<TransactionID> => {
   try {
     const response = await axios.post(`${baseUrl}/tx`, txHex);
     if (response.status !== 200) throw new Error(response.data);

--- a/src/content/marina/marinaBroker.ts
+++ b/src/content/marina/marinaBroker.ts
@@ -224,7 +224,7 @@ export default class MarinaBroker extends Broker {
 
           if (!txid) throw new Error('something went wrong with the tx broadcasting');
 
-          return successMsg(txid);
+          return successMsg({ txid, hex: signedTxHex });
         }
 
         case Marina.prototype.signMessage.name: {

--- a/src/inject/marina/provider.ts
+++ b/src/inject/marina/provider.ts
@@ -5,9 +5,9 @@ import {
   MarinaProvider,
   PsetBase64,
   Recipient,
+  SentTransaction,
   SignedMessage,
   Transaction,
-  TransactionID,
   Utxo,
 } from 'marina-provider';
 import MarinaEventHandler from './marinaEventHandler';
@@ -63,7 +63,7 @@ export default class Marina extends WindowProxy implements MarinaProvider {
     return this.proxy(this.blindTransaction.name, [psetBase64]);
   }
 
-  sendTransaction(recipients: Recipient[], feeAssetHash?: string): Promise<TransactionID> {
+  sendTransaction(recipients: Recipient[], feeAssetHash?: string): Promise<SentTransaction> {
     if (!recipients || !Array.isArray(recipients) || recipients.length === 0) {
       throw new Error('invalid recipients array');
     }

--- a/src/inject/marina/provider.ts
+++ b/src/inject/marina/provider.ts
@@ -1,14 +1,14 @@
 import {
-  MarinaProvider,
   AddressInterface,
-  PsetBase64,
-  SignedMessage,
-  Transaction,
-  Utxo,
   Balance,
   MarinaEventType,
+  MarinaProvider,
+  PsetBase64,
   Recipient,
+  SignedMessage,
+  Transaction,
   TransactionID,
+  Utxo,
 } from 'marina-provider';
 import MarinaEventHandler from './marinaEventHandler';
 import WindowProxy from '../proxy';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6718,10 +6718,10 @@ marina-provider@^1.0.0:
   resolved "https://registry.yarnpkg.com/marina-provider/-/marina-provider-1.4.5.tgz#2ec20ac786f7a333c9f2ed9f515a3a464d039eb8"
   integrity sha512-jnckZGyPIg0wS/+KgFO2yAwE6isk3KxrxWOeFNStUR5fZOgUwtREV5J7wEfvoGZ3yW9H++fMR72SbJ+KHct1Vw==
 
-marina-provider@^1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/marina-provider/-/marina-provider-1.4.7.tgz#0e3005c6a61bbdc9e89d44b82bcf2d518b24f0d6"
-  integrity sha512-f+hxp9/uthJAB8mE2pHjhpUyQGkwOFnGCE+kGg/mL7Xi1qJEtMaRDdVd7aKTq+NY9wF/Qng8fV+eB8Esxk5sIA==
+marina-provider@^1.4.8:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/marina-provider/-/marina-provider-1.4.8.tgz#7d5b2dc2c7dc5df11caa13efca2750a1d74c3f08"
+  integrity sha512-sZSuVxbqxq4Bev0cmJussww1MOXO+VzsS3nbxBD5nsqKUJUVDCzNo6ERLiXkeT9JZTg1kyaCrr80Ed4M2QBYkQ==
 
 marky@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
fixes #310 

Before merging:
- Accept PR https://github.com/vulpemventures/marina-provider/pull/17
- Bump marina-provider to 1.4.8 (expected new version)
- yarn install and commit new yarn.lock

Additional fixes/improvements:
- [fix correct return type for broadcastTx](https://github.com/vulpemventures/marina/commit/7c634cf196ba5ff37352e1355e205146bb1fc6f5)
- [puts import type in alphabetical order](https://github.com/vulpemventures/marina/commit/072258be2bd863310fb8a25593df64aa6d86a886)

@tiero please review