### PR TITLE
Makes popup prompt appear on top right of the screen

### DIFF
--- a/src/background/background-script.ts
+++ b/src/background/background-script.ts
@@ -149,13 +149,17 @@ async function openInitializeWelcomeRoute(): Promise<number | undefined> {
 const POPUP_HTML = 'popup.html';
 
 async function createBrowserPopup(name?: PopupName) {
+  const [defaultWindowWidth, rightMargin] = [1360, 100];
+  const window = await browser.windows.getLastFocused().catch(console.error);
+  const windowWidth = window?.width || defaultWindowWidth;
+  const width = 360; // popup width
   const options = {
     url: `${POPUP_HTML}#/connect/${name}`,
     type: 'popup',
     height: 600,
-    width: 360,
+    width,
     focused: true,
-    left: 100,
+    left: windowWidth - rightMargin - width,
     top: 100,
   };
   await browser.windows.create(options as any);

--- a/src/background/background-script.ts
+++ b/src/background/background-script.ts
@@ -147,20 +147,33 @@ async function openInitializeWelcomeRoute(): Promise<number | undefined> {
 }
 
 const POPUP_HTML = 'popup.html';
+const POPUP_HEIGHT = 600;
+const POPUP_WIDTH = 360;
 
 async function createBrowserPopup(name?: PopupName) {
-  const [defaultWindowWidth, rightMargin] = [1360, 100];
-  const window = await browser.windows.getLastFocused().catch(console.error);
-  const windowWidth = window?.width || defaultWindowWidth;
-  const width = 360; // popup width
+  let _left = 0;
+  let _top = 0;
+  try {
+    // Position popup in top right corner of window.
+    const { left, top, width } = await browser.windows.getLastFocused();
+    if (typeof left !== 'undefined' && typeof top !== 'undefined' && typeof width !== 'undefined') {
+      _top = top;
+      _left = left + (width - POPUP_WIDTH);
+    }
+  } catch (_) {
+    // The following properties are more than likely to be 0
+    const { screenX, screenY, outerWidth } = window;
+    _top = Math.max(screenY, 0);
+    _left = Math.max(screenX + (outerWidth - POPUP_WIDTH), 0);
+  }
   const options = {
     url: `${POPUP_HTML}#/connect/${name}`,
     type: 'popup',
-    height: 600,
-    width,
+    height: POPUP_HEIGHT,
+    width: POPUP_WIDTH,
     focused: true,
-    left: windowWidth - rightMargin - width,
-    top: 100,
+    left: _left,
+    top: _top,
   };
   await browser.windows.create(options as any);
 }


### PR DESCRIPTION
Since `browser.windows.create` options doesn't allow `right`, we need
to calculate `left` with window width, popup width, and some margin.

@tiero please review