### PR TITLE
[Onboarding] Moved seed validation from onChange event handler to onBlur event handler

### DIFF
--- a/src/presentation/onboarding/wallet-restore/mnemonic-field.tsx
+++ b/src/presentation/onboarding/wallet-restore/mnemonic-field.tsx
@@ -15,12 +15,13 @@ export const MnemonicField: React.FC<Props> = ({ onChange, value }) => {
   };
 
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    if (!validSeed(event.target.value)) {
+    setError(undefined);
+    onChange(event.target.value);
+  };
+
+  const handleBlur = () => {
+    if (!validSeed(value)) {
       setError('Mnemonic is not valid - should be 12 or 24 words separated by spaces');
-      onChange('');
-    } else {
-      setError(undefined);
-      onChange(event.target.value);
     }
   };
 
@@ -38,6 +39,7 @@ export const MnemonicField: React.FC<Props> = ({ onChange, value }) => {
           }
         )}
         onChange={handleChange}
+        onBlur={handleBlur}
         placeholder="Enter your mnemonic phrase"
         value={value}
       />


### PR DESCRIPTION
I was going to add custom error messages for detection of new lines as well since entering a new line between words (without spaces) will register a '\n' as part of the words in the seed phrase, but I'm not sure if that needs to be addressed

This closes: #362 