### PR TITLE
naming fix + select only spendableByMarina accounts in UI

### DIFF
--- a/src/application/redux/actions/wallet.ts
+++ b/src/application/redux/actions/wallet.ts
@@ -50,14 +50,10 @@ export function setIsSpendableByMarina(accountID: AccountID, isSpendableByMarina
   };
 }
 
-export function setCustomScriptTemplate(
-  accountID: AccountID,
-  template: string,
-  changeTemplate?: string
-): AnyAction {
+export function setCustomScriptTemplate(accountID: AccountID, template: string): AnyAction {
   return {
     type: SET_CS_ACCOUNT_TEMPLATE,
-    payload: { accountID, template, changeTemplate },
+    payload: { accountID, template },
   };
 }
 

--- a/src/application/redux/containers/home.container.ts
+++ b/src/application/redux/containers/home.container.ts
@@ -5,13 +5,13 @@ import HomeView from '../../../presentation/wallet/home';
 import { selectBalances } from '../selectors/balance.selector';
 import { assetGetterFromIAssets } from '../../../domain/assets';
 import { lbtcAssetByNetwork } from '../../utils/network';
-import { selectAllAccountsIDs } from '../selectors/wallet.selector';
+import { selectAllAccountsIDsSpendableViaUI } from '../selectors/wallet.selector';
 
 const mapStateToProps = (state: RootReducerState): HomeProps => {
   return {
     lbtcAssetHash: lbtcAssetByNetwork(state.app.network),
     transactionStep: state.transaction.step,
-    assetsBalance: selectBalances(...selectAllAccountsIDs(state))(state),
+    assetsBalance: selectBalances(...selectAllAccountsIDsSpendableViaUI(state))(state),
     getAsset: assetGetterFromIAssets(state.assets),
   };
 };

--- a/src/application/redux/containers/receive-select-asset.container.ts
+++ b/src/application/redux/containers/receive-select-asset.container.ts
@@ -4,10 +4,10 @@ import type { RootReducerState } from '../../../domain/common';
 import type { ReceiveSelectAssetProps } from '../../../presentation/wallet/receive/receive-select-asset';
 import ReceiveSelectAssetView from '../../../presentation/wallet/receive/receive-select-asset';
 import { selectBalances } from '../selectors/balance.selector';
-import { selectAllAccountsIDs } from '../selectors/wallet.selector';
+import { selectAllAccountsIDsSpendableViaUI } from '../selectors/wallet.selector';
 
 const mapStateToProps = (state: RootReducerState): ReceiveSelectAssetProps => {
-  const balances = selectBalances(...selectAllAccountsIDs(state))(state);
+  const balances = selectBalances(...selectAllAccountsIDsSpendableViaUI(state))(state);
   const getAsset = assetGetterFromIAssets(state.assets);
   return {
     network: state.app.network,

--- a/src/application/redux/containers/transactions.container.ts
+++ b/src/application/redux/containers/transactions.container.ts
@@ -3,11 +3,14 @@ import type { RootReducerState } from '../../../domain/common';
 import type { TransactionsProps } from '../../../presentation/wallet/transactions';
 import TransactionsView from '../../../presentation/wallet/transactions';
 import { selectElectrsURL, selectNetwork } from '../selectors/app.selector';
-import { selectAllAccountsIDs, selectTransactions } from '../selectors/wallet.selector';
+import {
+  selectAllAccountsIDsSpendableViaUI,
+  selectTransactions,
+} from '../selectors/wallet.selector';
 
 const mapStateToProps = (state: RootReducerState): TransactionsProps => ({
   assets: state.assets,
-  transactions: selectTransactions(...selectAllAccountsIDs(state))(state),
+  transactions: selectTransactions(...selectAllAccountsIDsSpendableViaUI(state))(state),
   webExplorerURL: selectElectrsURL(state),
   network: selectNetwork(state),
   isWalletVerified: state.wallet.isVerified,

--- a/src/application/redux/reducers/wallet-reducer.ts
+++ b/src/application/redux/reducers/wallet-reducer.ts
@@ -161,8 +161,8 @@ export function walletReducer(
           ...state.accounts,
           [payload.accountID as AccountID]: {
             ...state.accounts[payload.accountID],
-            covenantDescriptors: {
-              ...state.accounts[payload.accountID].covenantDescriptors,
+            contractTemplate: {
+              ...state.accounts[payload.accountID].contractTemplate,
               isSpendableByMarina: payload.isSpendableByMarina,
             },
           },
@@ -176,10 +176,9 @@ export function walletReducer(
 
       const accountWithTemplate: CustomScriptAccountData = {
         ...(state.accounts[accountID] as CustomScriptAccountData),
-        covenantDescriptors: {
+        contractTemplate: {
           namespace: payload.accountID,
           template: payload.template,
-          changeTemplate: payload.changeTemplate,
         },
       };
 

--- a/src/application/redux/selectors/wallet.selector.ts
+++ b/src/application/redux/selectors/wallet.selector.ts
@@ -119,7 +119,7 @@ export const selectAllAccountsIDsSpendableViaUI = (state: RootReducerState): Acc
   return selectAllAccountsIDs(state).filter(
     (id) =>
       state.wallet.accounts[id].type !== AccountType.CustomScriptAccount ||
-      (state.wallet.accounts[id] as CustomScriptAccountData).covenantDescriptors.isSpendableByMarina
+      (state.wallet.accounts[id] as CustomScriptAccountData).contractTemplate.isSpendableByMarina
   );
 };
 

--- a/src/application/utils/constants.ts
+++ b/src/application/utils/constants.ts
@@ -43,6 +43,8 @@ featuredAssetsMap.set(featuredAssets.lcad.mainnet, getLocalImagePath('lcad.png')
 featuredAssetsMap.set(featuredAssets.lcad.testnet, getLocalImagePath('lcad.png'));
 featuredAssetsMap.set(featuredAssets.fusd.testnet, getLocalImagePath('fusd.png'));
 
+export const FEATURES_ASSETS = Array.from(featuredAssetsMap.keys());
+
 // given an asset hash, return url for image path from mempool
 const getRemoteImagePath = (hash: string) => `https://liquid.network/api/v1/asset/${hash}/icon`;
 

--- a/src/application/utils/constants.ts
+++ b/src/application/utils/constants.ts
@@ -43,7 +43,7 @@ featuredAssetsMap.set(featuredAssets.lcad.mainnet, getLocalImagePath('lcad.png')
 featuredAssetsMap.set(featuredAssets.lcad.testnet, getLocalImagePath('lcad.png'));
 featuredAssetsMap.set(featuredAssets.fusd.testnet, getLocalImagePath('fusd.png'));
 
-export const FEATURES_ASSETS = Array.from(featuredAssetsMap.keys());
+export const FEATURED_ASSETS = Array.from(featuredAssetsMap.keys());
 
 // given an asset hash, return url for image path from mempool
 const getRemoteImagePath = (hash: string) => `https://liquid.network/api/v1/asset/${hash}/icon`;

--- a/src/domain/account.ts
+++ b/src/domain/account.ts
@@ -130,26 +130,25 @@ function createCustomScriptAccount(
     type: AccountType.CustomScriptAccount,
     getSigningIdentity: (password: string, network: NetworkString) =>
       restoredCustomScriptIdentity(
-        data.covenantDescriptors,
+        data.contractTemplate,
         decrypt(encryptedMnemonic, password),
         network,
         data.restorerOpts[network]
       ),
     getWatchIdentity: (network: NetworkString) =>
       restoredCustomScriptWatchOnlyIdentity(
-        data.covenantDescriptors,
+        data.contractTemplate,
         data.masterXPub,
         data.masterBlindingKey,
         network,
         data.restorerOpts[network]
       ),
     getInfo: () => ({
-      accountID: data.covenantDescriptors.namespace,
+      accountID: data.contractTemplate.namespace,
       masterXPub: data.masterXPub,
-      isReady: data.covenantDescriptors.template !== undefined,
-      changeTemplate: data.covenantDescriptors.changeTemplate,
-      template: data.covenantDescriptors.template,
-      isSpendableByMarina: data.covenantDescriptors.isSpendableByMarina,
+      isReady: data.contractTemplate.template !== undefined,
+      template: data.contractTemplate.template,
+      isSpendableByMarina: data.contractTemplate.isSpendableByMarina,
     }),
   };
 }

--- a/src/presentation/utils/sort.ts
+++ b/src/presentation/utils/sort.ts
@@ -1,3 +1,4 @@
+import { FEATURES_ASSETS } from '../../application/utils/constants';
 import type { Asset } from '../../domain/assets';
 
 /**
@@ -12,22 +13,19 @@ export function sortAssets(
 ): (Asset & { assetHash: string })[] {
   let newAsset;
   const newAssetTicker = 'Any';
-  const sortedFeaturedTickers = ['L-BTC', 'USDT', 'LCAD'];
   const featuredAssets: (Asset & { assetHash: string })[] = [];
-  // push featured assets in order
-  for (const ticker of sortedFeaturedTickers) {
-    for (const asset of assets) {
-      if (ticker === asset.ticker) {
-        featuredAssets.push(asset);
-      }
-      if (asset.ticker === newAssetTicker) {
-        newAsset = asset;
-      }
+  const remainingAssets = [];
+  for (const asset of assets) {
+    if (FEATURES_ASSETS.includes(asset.assetHash)) {
+      featuredAssets.push(asset);
+      continue;
+    }
+    if (asset.ticker === newAssetTicker) {
+      newAsset = asset;
+    } else {
+      remainingAssets.push(asset);
     }
   }
-  // get remaining assets - also includes new asset (has ticker 'Any')
-  const forbiddenTickers = [...sortedFeaturedTickers, newAssetTicker];
-  const remainingAssets = assets.filter((asset) => !forbiddenTickers.includes(asset.ticker));
   // join the two sets of assets and add 'Any' at the end of the list if it exists
   const sortedAssets = [...featuredAssets, ...remainingAssets];
   if (newAsset) sortedAssets.push(newAsset);

--- a/src/presentation/utils/sort.ts
+++ b/src/presentation/utils/sort.ts
@@ -1,4 +1,4 @@
-import { FEATURES_ASSETS } from '../../application/utils/constants';
+import { FEATURED_ASSETS } from '../../application/utils/constants';
 import type { Asset } from '../../domain/assets';
 
 /**
@@ -16,7 +16,7 @@ export function sortAssets(
   const featuredAssets: (Asset & { assetHash: string })[] = [];
   const remainingAssets = [];
   for (const asset of assets) {
-    if (FEATURES_ASSETS.includes(asset.assetHash)) {
+    if (FEATURED_ASSETS.includes(asset.assetHash)) {
       featuredAssets.push(asset);
       continue;
     }

--- a/src/presentation/wallet/home/index.tsx
+++ b/src/presentation/wallet/home/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useHistory } from 'react-router';
 import {
   RECEIVE_SELECT_ASSET_ROUTE,
@@ -58,13 +58,6 @@ const HomeView: React.FC<HomeProps> = ({
     return Object.keys(balances).map((hash) => getAsset(hash));
   };
 
-  // sorted assets
-  const [sortedAssets, setSortedAssets] = useState(sortAssets(assets(assetsBalance)));
-
-  useEffect(() => {
-    setSortedAssets(sortAssets(assets(assetsBalance)));
-  }, [assetsBalance]);
-
   useEffect(() => {
     switch (transactionStep) {
       case 'address-amount':
@@ -102,7 +95,7 @@ const HomeView: React.FC<HomeProps> = ({
 
         <div className="h-60">
           <ButtonList title="Assets" emptyText="You don't own any asset...">
-            {sortedAssets.map(
+            {sortAssets(assets(assetsBalance)).map(
               (
                 { assetHash, name, ticker, precision }: Asset & { assetHash: string },
                 index: React.Key


### PR DESCRIPTION
* HOTFIX: "CustomScriptData.covenantDescriptors" renamed into "contractTemplate" (has been renamed in former PR but some parts of the code still use the empty "covenantDescriptors" field).
* UI selects only the accounts spendable by marina UI (for balances, utxos and transactions). it closes #374 

@tiero please review 