### PR TITLE
Bug fix and improvement on marina events

### DIFF
--- a/src/application/redux/sagas/updater.ts
+++ b/src/application/redux/sagas/updater.ts
@@ -114,8 +114,7 @@ function* utxosUpdater(
   if (Object.keys(receivedUtxos).length > 0) {
     yield put(unlockUtxos());
   }
-
-  console.debug(`${new Date()} utxos received`, receivedUtxos);
+  console.debug(`${new Date()} utxos received for ${accountID}`, receivedUtxos);
 }
 
 const putAddTxAction = (accountID: AccountID, network: NetworkString, walletScripts: string[]) =>

--- a/src/content/marina/marinaBroker.ts
+++ b/src/content/marina/marinaBroker.ts
@@ -94,8 +94,9 @@ export default class MarinaBroker extends Broker<keyof Marina> {
     this.store.subscribe(() => {
       if (!this.store) throw MarinaBroker.NotSetUpError;
       const state = this.store.getState();
-      const newCache = newCacheFromState(state);
-      const events = compareCacheForEvents(newCache, this.cache, this.hostname);
+      const allAccountsIDs = selectAllAccountsIDs(state)
+      const newCache = newCacheFromState(state, allAccountsIDs);
+      const events = compareCacheForEvents(newCache, this.cache, this.hostname, allAccountsIDs);
 
       this.cache = newCache; // update the cache state
 

--- a/src/content/marina/marinaBroker.ts
+++ b/src/content/marina/marinaBroker.ts
@@ -94,7 +94,7 @@ export default class MarinaBroker extends Broker<keyof Marina> {
     this.store.subscribe(() => {
       if (!this.store) throw MarinaBroker.NotSetUpError;
       const state = this.store.getState();
-      const allAccountsIDs = selectAllAccountsIDs(state)
+      const allAccountsIDs = selectAllAccountsIDs(state);
       const newCache = newCacheFromState(state, allAccountsIDs);
       const events = compareCacheForEvents(newCache, this.cache, this.hostname, allAccountsIDs);
 

--- a/src/content/store-cache.ts
+++ b/src/content/store-cache.ts
@@ -1,5 +1,10 @@
 import type { NetworkString, UnblindedOutput } from 'ldk';
-import type { MarinaEvent } from '../application/utils/marina-event';
+import type {
+  MarinaEvent,
+  NewTxMarinaEvent,
+  NewUtxoMarinaEvent,
+  SpentUtxoMarinaEvent,
+} from '../application/utils/marina-event';
 import {
   compareEnabledWebsites,
   compareTxsHistoryState,
@@ -10,17 +15,25 @@ import { MainAccountID } from '../domain/account';
 import type { RootReducerState } from '../domain/common';
 import type { TxsHistory } from '../domain/transaction';
 
-export interface StoreCache {
+export interface StoreCacheAccount {
   utxoState: Record<string, UnblindedOutput>;
   txsHistoryState: TxsHistory;
+}
+
+export interface StoreCache {
+  accounts: Record<string, StoreCacheAccount>;
   enabledWebsitesState: Record<NetworkString, string[]>;
   network: NetworkString;
 }
 
 export function newStoreCache(): StoreCache {
-  return {
+  const accounts: Record<string, StoreCacheAccount> = {}
+  accounts[MainAccountID] = {
     utxoState: {},
     txsHistoryState: {},
+  }
+  return {
+    accounts,
     enabledWebsitesState: { regtest: [], liquid: [], testnet: [] },
     network: 'liquid',
   };
@@ -31,10 +44,23 @@ export function newStoreCache(): StoreCache {
 export function compareCacheForEvents(
   newCache: StoreCache,
   oldCache: StoreCache,
-  hostname: string // for ENABLED and DISABLED events
+  hostname: string, // for ENABLED and DISABLED events
+  allAccountsIDs: string[] // for UTXO and TX events
 ): MarinaEvent<any>[] {
-  const utxosEvents = compareUtxoState(oldCache.utxoState, newCache.utxoState);
-  const txsEvents = compareTxsHistoryState(oldCache.txsHistoryState, newCache.txsHistoryState);
+  const txsEvents: NewTxMarinaEvent[] = [];
+  const utxosEvents: (NewUtxoMarinaEvent | SpentUtxoMarinaEvent)[] = [];
+  for (const accountID of allAccountsIDs) {
+    compareUtxoState(
+      oldCache.accounts[accountID]?.utxoState || {},
+      newCache.accounts[accountID]?.utxoState || {},
+      accountID
+    ).map((ev) => utxosEvents.push(ev));
+    compareTxsHistoryState(
+      oldCache.accounts[accountID]?.txsHistoryState || {},
+      newCache.accounts[accountID]?.txsHistoryState || {},
+      accountID
+    ).map((ev) => txsEvents.push(ev));
+  }
   const enabledAndDisabledEvents = compareEnabledWebsites(
     oldCache.enabledWebsitesState,
     newCache.enabledWebsitesState,
@@ -46,11 +72,17 @@ export function compareCacheForEvents(
 }
 
 // create cache from State.
-export function newCacheFromState(state: RootReducerState): StoreCache {
+export function newCacheFromState(state: RootReducerState, allAccountsIDs: string[]): StoreCache {
+  const accounts: Record<string, StoreCacheAccount> = {};
+  for (const accountID of allAccountsIDs) {
+    const root = state.wallet.unspentsAndTransactions[accountID][state.app.network];
+    accounts[accountID] = {
+      utxoState: root.utxosMap,
+      txsHistoryState: root.transactions,
+    };
+  }
   return {
-    utxoState: state.wallet.unspentsAndTransactions[MainAccountID][state.app.network].utxosMap,
-    txsHistoryState:
-      state.wallet.unspentsAndTransactions[MainAccountID][state.app.network].transactions,
+    accounts,
     enabledWebsitesState: state.connect.enabledSites,
     network: state.app.network,
   };

--- a/src/content/store-cache.ts
+++ b/src/content/store-cache.ts
@@ -27,11 +27,11 @@ export interface StoreCache {
 }
 
 export function newStoreCache(): StoreCache {
-  const accounts: Record<string, StoreCacheAccount> = {}
+  const accounts: Record<string, StoreCacheAccount> = {};
   accounts[MainAccountID] = {
     utxoState: {},
     txsHistoryState: {},
-  }
+  };
   return {
     accounts,
     enabledWebsitesState: { regtest: [], liquid: [], testnet: [] },


### PR DESCRIPTION
Closes #377

**Bug fixes:**

- fix bug where only the main account was emitting events on `NEW_TX`, `NEW_UTXO` and `SPENT_UTXO`

**Improvements:**

- marina events (see list above) now returns the accountID in the payload

**Breaking changes (marina events):**

- `marina.on('NEW_TX', (tx) => {})` is now `marina.on('NEW_TX', ({ tx, accountID }) => {})`
- `marina.on('NEW_UTXO', (utxo) => {})` is now `marina.on('NEW_UTXO', ({ utxo, accountID }) => {})`
- `marina.on('SPENT_UTXO', (utxo) => {})` is now `marina.on('SPENT_UTXO', ({ utxo, accountID }) => {})`

**Worth mentioning:**

- adds accountID to console.debug when reporting utxos fetched from explorer

@tiero @louisinger please review.
