### PR TITLE
add walletState V4 migration

### DIFF
--- a/src/application/redux/reducers/index.ts
+++ b/src/application/redux/reducers/index.ts
@@ -107,7 +107,7 @@ const marinaReducer = combineReducers({
     reducer: walletReducer,
     key: 'wallet',
     blacklist: ['deepRestorer', 'updaterLoaders'],
-    version: 3,
+    version: 4,
     migrate: walletMigrate,
   }),
   taxi: persist<TaxiState>({

--- a/src/domain/migrations.ts
+++ b/src/domain/migrations.ts
@@ -66,7 +66,9 @@ export const walletMigrations = {
   },
 };
 
-function accountsFieldRenameV4(accounts: WalletPersistedStateV3['accounts']): WalletPersistedStateV4['accounts'] {
+function accountsFieldRenameV4(
+  accounts: WalletPersistedStateV3['accounts']
+): WalletPersistedStateV4['accounts'] {
   const renamed: WalletPersistedStateV4['accounts'] = {};
   for (const [id, account] of Object.entries(accounts)) {
     renamed[id] = {

--- a/test/migrations.spec.ts
+++ b/test/migrations.spec.ts
@@ -1,6 +1,10 @@
 import { assert } from 'chai';
 import { AccountType, initialRestorerOpts, MainAccountID } from '../src/domain/account';
-import type { WalletPersistedStateV1, WalletPersistedStateV2, WalletPersistedStateV3 } from '../src/domain/migrations';
+import type {
+  WalletPersistedStateV1,
+  WalletPersistedStateV2,
+  WalletPersistedStateV3,
+} from '../src/domain/migrations';
 import { walletMigrations } from '../src/domain/migrations';
 
 describe('WalletState migrations', () => {
@@ -27,16 +31,20 @@ describe('WalletState migrations', () => {
           covenantDescriptors: {
             namespace: 'custom-account',
             template: 'raw(00010203)',
-          }
-        }
+          },
+        },
       },
       updaterLoaders: 0,
       lockedUtxos: {},
-    }
+    };
     const walletStateV4 = walletMigrations[4](walletStateV3);
-    expect(walletStateV4.accounts['customAccount'].contractTemplate.template).toEqual(walletStateV3.accounts['customAccount'].covenantDescriptors.template);
-    expect(walletStateV4.accounts['customAccount'].contractTemplate.namespace).toEqual(walletStateV3.accounts['customAccount'].covenantDescriptors.namespace);
-  })
+    expect(walletStateV4.accounts['customAccount'].contractTemplate.template).toEqual(
+      walletStateV3.accounts['customAccount'].covenantDescriptors.template
+    );
+    expect(walletStateV4.accounts['customAccount'].contractTemplate.namespace).toEqual(
+      walletStateV3.accounts['customAccount'].covenantDescriptors.namespace
+    );
+  });
 
   it('should be able to migrate from v2 to v3', () => {
     const walletStateV2: WalletPersistedStateV2 = {
@@ -57,16 +65,22 @@ describe('WalletState migrations', () => {
       },
       updaterLoaders: 0,
       lockedUtxos: {},
-    }
+    };
 
     const walletStateV3 = walletMigrations[3](walletStateV2);
     expect(walletStateV3.encryptedMnemonic).toEqual(walletStateV2.mainAccount.encryptedMnemonic);
     expect(walletStateV3.accounts[MainAccountID].type).toEqual(AccountType.MainAccount);
-    expect(walletStateV3.accounts[MainAccountID].masterBlindingKey).toEqual(walletStateV2.mainAccount.masterBlindingKey);
-    expect(walletStateV3.accounts[MainAccountID].masterXPub).toEqual(walletStateV2.mainAccount.masterXPub);
-    expect(walletStateV3.accounts[MainAccountID].restorerOpts).toEqual(walletStateV2.mainAccount.restorerOpts);
+    expect(walletStateV3.accounts[MainAccountID].masterBlindingKey).toEqual(
+      walletStateV2.mainAccount.masterBlindingKey
+    );
+    expect(walletStateV3.accounts[MainAccountID].masterXPub).toEqual(
+      walletStateV2.mainAccount.masterXPub
+    );
+    expect(walletStateV3.accounts[MainAccountID].restorerOpts).toEqual(
+      walletStateV2.mainAccount.restorerOpts
+    );
     expect(walletStateV3.passwordHash).toEqual(walletStateV2.passwordHash);
-  })
+  });
 
   it('should be able to migrate from v1 to v2', () => {
     const walletStateV1: WalletPersistedStateV1 = {

--- a/test/migrations.spec.ts
+++ b/test/migrations.spec.ts
@@ -1,9 +1,74 @@
 import { assert } from 'chai';
-import type { WalletPersistedStateV1 } from '../src/domain/migrations';
+import { AccountType, initialRestorerOpts, MainAccountID } from '../src/domain/account';
+import type { WalletPersistedStateV1, WalletPersistedStateV2, WalletPersistedStateV3 } from '../src/domain/migrations';
 import { walletMigrations } from '../src/domain/migrations';
 
-describe('migration from v1 to v2', () => {
-  it('should be able to compute v2 from v1', () => {
+describe('WalletState migrations', () => {
+  it('should be able to migrate from v3 to v4', () => {
+    const walletStateV3: WalletPersistedStateV3 = {
+      deepRestorer: { gapLimit: 20, restorerLoaders: 0 },
+      isVerified: true,
+      passwordHash: 'password hash',
+      unspentsAndTransactions: {},
+      encryptedMnemonic: '08e53a2e9e3ed3ba34dd5ce7f94e1e62abc3549e2d8796d8cd01102a23af1a',
+      accounts: {
+        mainAccount: {
+          masterBlindingKey: 'master blinding key',
+          masterXPub: 'master extended pub',
+          type: AccountType.MainAccount,
+          restorerOpts: {
+            liquid: initialRestorerOpts,
+            testnet: initialRestorerOpts,
+            regtest: initialRestorerOpts,
+          },
+        },
+        customAccount: {
+          type: AccountType.CustomScriptAccount,
+          covenantDescriptors: {
+            namespace: 'custom-account',
+            template: 'raw(00010203)',
+          }
+        }
+      },
+      updaterLoaders: 0,
+      lockedUtxos: {},
+    }
+    const walletStateV4 = walletMigrations[4](walletStateV3);
+    expect(walletStateV4.accounts['customAccount'].contractTemplate.template).toEqual(walletStateV3.accounts['customAccount'].covenantDescriptors.template);
+    expect(walletStateV4.accounts['customAccount'].contractTemplate.namespace).toEqual(walletStateV3.accounts['customAccount'].covenantDescriptors.namespace);
+  })
+
+  it('should be able to migrate from v2 to v3', () => {
+    const walletStateV2: WalletPersistedStateV2 = {
+      deepRestorer: { gapLimit: 20, restorerLoaders: 0 },
+      isVerified: true,
+      passwordHash: 'password hash',
+      unspentsAndTransactions: {},
+      mainAccount: {
+        masterBlindingKey: 'master blinding key',
+        masterXPub: 'master extended pub',
+        encryptedMnemonic: '08e53a2e9e3ed3ba34dd5ce7f94e1e62abc3549e2d8796d8cd01102a23af1a',
+        type: AccountType.MainAccount,
+        restorerOpts: {
+          liquid: initialRestorerOpts,
+          testnet: initialRestorerOpts,
+          regtest: initialRestorerOpts,
+        },
+      },
+      updaterLoaders: 0,
+      lockedUtxos: {},
+    }
+
+    const walletStateV3 = walletMigrations[3](walletStateV2);
+    expect(walletStateV3.encryptedMnemonic).toEqual(walletStateV2.mainAccount.encryptedMnemonic);
+    expect(walletStateV3.accounts[MainAccountID].type).toEqual(AccountType.MainAccount);
+    expect(walletStateV3.accounts[MainAccountID].masterBlindingKey).toEqual(walletStateV2.mainAccount.masterBlindingKey);
+    expect(walletStateV3.accounts[MainAccountID].masterXPub).toEqual(walletStateV2.mainAccount.masterXPub);
+    expect(walletStateV3.accounts[MainAccountID].restorerOpts).toEqual(walletStateV2.mainAccount.restorerOpts);
+    expect(walletStateV3.passwordHash).toEqual(walletStateV2.passwordHash);
+  })
+
+  it('should be able to migrate from v1 to v2', () => {
     const walletStateV1: WalletPersistedStateV1 = {
       deepRestorer: { gapLimit: 20, restorerLoaders: 0 },
       encryptedMnemonic: '08e53a2e9e3ed3ba34dd5ce7f94e1e62abc3549e2d8796d8cd01102a23af1a',


### PR DESCRIPTION
* PR #366 renamed `covenantDescriptors` field into `covenantTemplate`
* a fix about variable naming in PR #376 has been published but need a migration to handle renaming in case of the user still have former version of the reducer.

This PR ensures that the wallet reducers with version 3 (master reducer) are migrated to reducer version 4 (rename customScriptAccountData member).

Bonus: add a test for the V2 -> V3 migration

it closes #388 

@tiero please review