### PR TITLE
address-amount form: handle asset precision

### DIFF
--- a/src/application/redux/containers/send-select-asset.container.ts
+++ b/src/application/redux/containers/send-select-asset.container.ts
@@ -10,7 +10,9 @@ const mapStateToProps = (state: RootReducerState): SendSelectAssetProps => {
   const balances = selectBalances(...selectAllAccountsIDsSpendableViaUI(state))(state);
   const getAsset = assetGetterFromIAssets(state.assets);
   return {
-    balanceAssets: Object.keys(balances).filter(asset => balances[asset] > 0).map(getAsset),
+    balanceAssets: Object.keys(balances)
+      .filter((asset) => balances[asset] > 0)
+      .map(getAsset),
     balances,
   };
 };

--- a/src/application/redux/containers/send-select-asset.container.ts
+++ b/src/application/redux/containers/send-select-asset.container.ts
@@ -10,7 +10,7 @@ const mapStateToProps = (state: RootReducerState): SendSelectAssetProps => {
   const balances = selectBalances(...selectAllAccountsIDsSpendableViaUI(state))(state);
   const getAsset = assetGetterFromIAssets(state.assets);
   return {
-    balanceAssets: Object.keys(balances).map(getAsset),
+    balanceAssets: Object.keys(balances).filter(asset => balances[asset] > 0).map(getAsset),
     balances,
   };
 };

--- a/src/presentation/components/address-amount-form.tsx
+++ b/src/presentation/components/address-amount-form.tsx
@@ -70,6 +70,7 @@ const AddressAmountForm = (props: FormikProps<AddressAmountFormValues>) => {
         type="number"
         inputSuffix={values.assetTicker}
         validateOnChange={true}
+        step={getMinAmountFromPrecision(values.assetPrecision).toString()}
         {...props}
       />
 
@@ -96,7 +97,7 @@ const AddressAmountEnhancedForm = withFormik<AddressAmountFormProps, AddressAmou
     // https://github.com/formium/formik/issues/321#issuecomment-478364302
     amount:
       props.transaction.sendAmount > 0
-        ? fromSatoshi(props.transaction.sendAmount ?? 0, props.asset.precision)
+        ? (props.transaction.sendAmount ?? 0) * (10 ** props.asset.precision)
         : ('' as unknown as number),
     assetTicker: props.asset.ticker ?? '??',
     assetPrecision: props.asset.precision,

--- a/src/presentation/components/address-amount-form.tsx
+++ b/src/presentation/components/address-amount-form.tsx
@@ -2,7 +2,6 @@ import type { FormikProps } from 'formik';
 import { withFormik } from 'formik';
 import type { RouteComponentProps } from 'react-router';
 import type { ProxyStoreDispatch } from '../../application/redux/proxyStore';
-import cx from 'classnames';
 import Button from './button';
 import {
   setAddressesAndAmount,
@@ -18,6 +17,7 @@ import type { Account } from '../../domain/account';
 import type { NetworkString } from 'ldk';
 import { isValidAddressForNetwork } from '../../application/utils/address';
 import { fromSatoshi, getMinAmountFromPrecision, toSatoshi } from '../utils';
+import Input from './input';
 
 interface AddressAmountFormValues {
   address: string;
@@ -38,17 +38,8 @@ interface AddressAmountFormProps {
 }
 
 const AddressAmountForm = (props: FormikProps<AddressAmountFormValues>) => {
-  const {
-    errors,
-    handleChange,
-    handleBlur,
-    handleSubmit,
-    isSubmitting,
-    touched,
-    values,
-    setFieldValue,
-    setFieldTouched,
-  } = props;
+  const { errors, handleSubmit, isSubmitting, touched, values, setFieldValue, setFieldTouched } =
+    props;
 
   const setMaxAmount = () => {
     const maxAmount = values.balance;
@@ -57,63 +48,13 @@ const AddressAmountForm = (props: FormikProps<AddressAmountFormValues>) => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="mt-10">
-      <div className={cx({ 'mb-12': !errors.address || !touched.address })}>
-        <label className="block">
-          <p className="mb-2 text-base font-medium text-left">Address</p>
-          <input
-            className={cx(
-              'border-2 focus:ring-primary focus:border-primary placeholder-grayLight block w-full rounded-md',
-              {
-                'border-red': errors.address && touched.address,
-                'border-grayLight': !errors.address || !touched.address,
-              }
-            )}
-            id="address"
-            name="address"
-            onChange={handleChange}
-            onBlur={handleBlur}
-            placeholder=""
-            type="text"
-            value={values.address}
-          />
-        </label>
-        {errors.address && touched.address && (
-          <p className="text-red h-10 mt-2 text-xs font-medium text-left">{errors.address}</p>
-        )}
-      </div>
+    <form onSubmit={handleSubmit} className="mt-8">
+      <p className="mb-2 text-base font-medium text-left">Address</p>
+      <Input name="address" placeholder="" type="text" {...props} />
 
-      <div className={cx({ 'mb-12': !errors.amount || !touched.amount })}>
-        <label className="block">
-          <p className="mb-2 text-base font-medium text-left">Amount</p>
-          <div
-            className={cx('focus-within:text-grayDark text-grayLight relative w-full', {
-              'text-grayDark': touched.amount,
-            })}
-          >
-            <input
-              className={cx(
-                'border-2 focus:ring-primary focus:border-primary placeholder-grayLight block w-full rounded-md',
-                {
-                  'border-red': errors.amount && touched.amount,
-                  'border-grayLight': !errors.amount || !touched.amount,
-                }
-              )}
-              id="amount"
-              name="amount"
-              onChange={handleChange}
-              onBlur={handleBlur}
-              placeholder="0"
-              type="number"
-              lang="en"
-              value={values.amount}
-            />
-            <span className="absolute inset-y-0 right-0 flex items-center pr-2 text-base font-medium">
-              {values.assetTicker}
-            </span>
-          </div>
-        </label>
-        <p className="text-primary text-right">
+      <div className="flex content-center justify-between mb-2">
+        <p className="text-base font-medium text-left">Amount</p>
+        <div className="text-primary text-right">
           <button
             onClick={setMaxAmount}
             className="background-transparent focus:outline-none px-3 py-1 mt-1 mb-1 mr-1 text-xs font-bold uppercase transition-all duration-150 ease-linear outline-none"
@@ -121,11 +62,16 @@ const AddressAmountForm = (props: FormikProps<AddressAmountFormValues>) => {
           >
             SEND ALL
           </button>
-        </p>
-        {errors.amount && touched.amount && (
-          <p className="text-red h-10 mt-1 text-xs font-medium text-left">{errors.amount}</p>
-        )}
+        </div>
       </div>
+      <Input
+        name="amount"
+        placeholder="0"
+        type="number"
+        inputSuffix={values.assetTicker}
+        validateOnChange={true}
+        {...props}
+      />
 
       <div className="text-right">
         <Button
@@ -160,7 +106,7 @@ const AddressAmountEnhancedForm = withFormik<AddressAmountFormProps, AddressAmou
   validationSchema: (props: AddressAmountFormProps): any =>
     Yup.object().shape({
       address: Yup.string()
-        .required('Please enter a valid address')
+        .required('Address is required')
         .test(
           'valid-address',
           'Address is not valid',
@@ -168,10 +114,19 @@ const AddressAmountEnhancedForm = withFormik<AddressAmountFormProps, AddressAmou
         ),
 
       amount: Yup.number()
-        .required('Please enter a valid amount')
+        .required('Amount is required')
         .min(
           getMinAmountFromPrecision(props.asset.precision),
           'Amount should be at least 1 satoshi'
+        )
+        .test(
+          'too-many-decimals',
+          `Too many decimals (precision: ${props.asset.precision})`,
+          (value) => {
+            const splitted = value?.toString(10).replace(',', '.').split('.');
+            if (splitted && splitted.length < 2) return true;
+            return splitted !== undefined && splitted[1].length <= props.asset.precision;
+          }
         )
         .test('insufficient-funds', 'Insufficient funds', (value) => {
           return value !== undefined && value <= fromSatoshi(props.balance, props.asset.precision);

--- a/src/presentation/components/address-amount-form.tsx
+++ b/src/presentation/components/address-amount-form.tsx
@@ -97,7 +97,7 @@ const AddressAmountEnhancedForm = withFormik<AddressAmountFormProps, AddressAmou
     // https://github.com/formium/formik/issues/321#issuecomment-478364302
     amount:
       props.transaction.sendAmount > 0
-        ? (props.transaction.sendAmount ?? 0) * (10 ** props.asset.precision)
+        ? (props.transaction.sendAmount ?? 0) * 10 ** props.asset.precision
         : ('' as unknown as number),
     assetTicker: props.asset.ticker ?? '??',
     assetPrecision: props.asset.precision,

--- a/src/presentation/components/input.tsx
+++ b/src/presentation/components/input.tsx
@@ -7,6 +7,7 @@ interface InputProps<FormValues> extends FormikProps<FormValues> {
   title?: string;
   type: 'text' | 'number' | 'password';
   inputSuffix?: string;
+  step?: string;
 }
 
 /**
@@ -14,16 +15,15 @@ interface InputProps<FormValues> extends FormikProps<FormValues> {
  */
 export default function Input<FormValues>({
   errors,
-  status,
   name,
   placeholder = '',
   title,
   touched,
   type = 'text',
-  values,
   handleChange,
   handleBlur,
   inputSuffix,
+  step,
 }: InputProps<FormValues>) {
   return (
     <div>
@@ -44,8 +44,8 @@ export default function Input<FormValues>({
             onBlur={handleBlur}
             placeholder={placeholder}
             type={type}
-            value={String(values[name])}
             lang="en"
+            {...(type === 'number' && { min: 0, step: step ?? 'any', inputmode: 'decimal' })}
           />
           {inputSuffix && (
             <span className="absolute inset-y-0 right-0 flex items-center pr-2 text-base font-medium">

--- a/src/presentation/components/input.tsx
+++ b/src/presentation/components/input.tsx
@@ -8,6 +8,7 @@ interface InputProps<FormValues> extends FormikProps<FormValues> {
   type: 'text' | 'number' | 'password';
   inputSuffix?: string;
   step?: string;
+  value?: string | number;
 }
 
 /**
@@ -24,6 +25,7 @@ export default function Input<FormValues>({
   handleBlur,
   inputSuffix,
   step,
+  value,
 }: InputProps<FormValues>) {
   return (
     <div>
@@ -38,6 +40,7 @@ export default function Input<FormValues>({
                 'border-grayLight': !errors[name],
               }
             )}
+            value={value}
             id={name.toString()}
             name={name.toString()}
             onChange={handleChange}
@@ -45,7 +48,7 @@ export default function Input<FormValues>({
             placeholder={placeholder}
             type={type}
             lang="en"
-            {...(type === 'number' && { min: 0, step: step ?? 'any', inputmode: 'decimal' })}
+            {...(type === 'number' && { min: 0, step: step ?? 'any', inputMode: 'decimal' })}
           />
           {inputSuffix && (
             <span className="absolute inset-y-0 right-0 flex items-center pr-2 text-base font-medium">

--- a/src/presentation/components/input.tsx
+++ b/src/presentation/components/input.tsx
@@ -5,7 +5,8 @@ interface InputProps<FormValues> extends FormikProps<FormValues> {
   name: keyof FormValues;
   placeholder?: string;
   title?: string;
-  type: 'text' | 'password';
+  type: 'text' | 'number' | 'password';
+  inputSuffix?: string;
 }
 
 /**
@@ -22,40 +23,40 @@ export default function Input<FormValues>({
   values,
   handleChange,
   handleBlur,
+  inputSuffix,
 }: InputProps<FormValues>) {
   return (
-    <div
-      className={cx({
-        'mb-12': !errors[name] || !touched[name],
-      })}
-    >
+    <div>
       <label className="block text-left">
         {title && <p className="mb-2 font-medium">{title}</p>}
-        <input
-          className={cx(
-            'border-2 focus:ring-primary focus:border-primary placeholder-grayLight block w-full sm:w-2/5 rounded-md',
-            {
-              'border-red': errors[name] && touched[name],
-              'border-grayLight': !errors[name],
-            }
+        <div className="relative">
+          <input
+            className={cx(
+              'border-2 focus:ring-primary focus:border-primary placeholder-grayLight block w-full sm:w-2/5 rounded-md',
+              {
+                'border-red': errors[name] && touched[name],
+                'border-grayLight': !errors[name],
+              }
+            )}
+            id={name.toString()}
+            name={name.toString()}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            placeholder={placeholder}
+            type={type}
+            value={String(values[name])}
+            lang="en"
+          />
+          {inputSuffix && (
+            <span className="absolute inset-y-0 right-0 flex items-center pr-2 text-base font-medium">
+              {inputSuffix}
+            </span>
           )}
-          id={name.toString()}
-          name={name.toString()}
-          onChange={handleChange}
-          onBlur={handleBlur}
-          placeholder={placeholder}
-          type={type}
-          value={String(values[name])}
-        />
+        </div>
       </label>
-      {status?.[name] ? (
-        <p className="text-red h-10 mt-2 text-xs text-left">{status[name]}</p>
-      ) : (
-        errors[name] &&
-        touched[name] && (
-          <p className="text-red h-10 mt-2 text-xs text-left">{errors[name] as string}</p>
-        )
-      )}
+      <p className="text-red h-10 mt-2 text-xs text-left">
+        {errors?.[name] ? errors[name]?.toString() : ''}
+      </p>
     </div>
   );
 }

--- a/src/presentation/components/input.tsx
+++ b/src/presentation/components/input.tsx
@@ -5,10 +5,9 @@ interface InputProps<FormValues> extends FormikProps<FormValues> {
   name: keyof FormValues;
   placeholder?: string;
   title?: string;
-  type: 'text' | 'number' | 'password';
+  type: 'text' | 'password';
   inputSuffix?: string;
-  step?: string;
-  value?: string | number;
+  value?: string;
 }
 
 /**
@@ -24,7 +23,6 @@ export default function Input<FormValues>({
   handleChange,
   handleBlur,
   inputSuffix,
-  step,
   value,
 }: InputProps<FormValues>) {
   return (
@@ -47,8 +45,6 @@ export default function Input<FormValues>({
             onBlur={handleBlur}
             placeholder={placeholder}
             type={type}
-            lang="en"
-            {...(type === 'number' && { min: 0, step: step ?? 'any', inputMode: 'decimal' })}
           />
           {inputSuffix && (
             <span className="absolute inset-y-0 right-0 flex items-center pr-2 text-base font-medium">


### PR DESCRIPTION
* refacto the address-amount form (use `Input` component instead of HTLM input)
* add a formik validation rule checking asset precision in amount field
* move the SEND ALL button **above** the amount field (fix weird margin in case of error) -> need ACK on this @tiero 

@tiero please review

it closes #406 