### PR TITLE
add Wallet migration v6 (make sure only xpub are in reducer)

### DIFF
--- a/src/application/redux/reducers/index.ts
+++ b/src/application/redux/reducers/index.ts
@@ -107,7 +107,7 @@ const marinaReducer = combineReducers({
     reducer: walletReducer,
     key: 'wallet',
     blacklist: ['deepRestorer', 'updaterLoaders'],
-    version: 5,
+    version: 6,
     migrate: walletMigrate,
   }),
   taxi: persist<TaxiState>({

--- a/src/domain/account.ts
+++ b/src/domain/account.ts
@@ -60,6 +60,8 @@ export interface Account<
 // it is used to discriminate account by their type
 export interface AccountData {
   type: AccountType;
+  masterXPub: MasterXPub;
+  masterBlindingKey: MasterBlindingKey;
   [key: string]: any;
 }
 
@@ -77,8 +79,6 @@ export type MnemonicAccount = Account<Mnemonic, MasterPublicKey> & {
 export interface MnemonicAccountData extends AccountData {
   type: AccountType.MainAccount;
   restorerOpts: Record<NetworkString, StateRestorerOpts>;
-  masterXPub: MasterXPub;
-  masterBlindingKey: MasterBlindingKey;
 }
 
 // custom script account is decribed with
@@ -94,8 +94,6 @@ export interface CustomScriptAccountData extends AccountData {
   type: AccountType.CustomScriptAccount;
   contractTemplate: ContractTemplate;
   restorerOpts: Record<NetworkString, CustomRestorerOpts>;
-  masterXPub: MasterXPub;
-  masterBlindingKey: MasterBlindingKey;
 }
 
 // Factory for mainAccount

--- a/src/domain/migrations.ts
+++ b/src/domain/migrations.ts
@@ -1,4 +1,4 @@
-import type { StateRestorerOpts} from 'ldk';
+import type { StateRestorerOpts } from 'ldk';
 import { toXpub } from 'ldk';
 import { createMigrate } from 'redux-persist';
 import type { PersistedState } from 'redux-persist/es/types';

--- a/test/migrations.spec.ts
+++ b/test/migrations.spec.ts
@@ -32,6 +32,8 @@ describe('WalletState migrations', () => {
             namespace: 'custom-account',
             template: 'raw(00010203)',
           },
+          masterBlindingKey: 'master blinding key',
+          masterXPub: 'master extended pub',
         },
       },
       updaterLoaders: 0,


### PR DESCRIPTION
This PR adds a new wallet state (V6) checking if any zpub, ypub etc... are in wallet reducer and convert them to `xpub...` master public keys.

@tiero please review

[marina-0.4.13-xpubhotfix.zip](https://github.com/vulpemventures/marina/files/9608577/marina-0.4.13.zip)

it closes #407 