### PR TITLE
marina provider getters with `undefined` accountsIDs param fallback to [MainAccountID]

### DIFF
--- a/src/content/marina/marinaBroker.ts
+++ b/src/content/marina/marinaBroker.ts
@@ -172,7 +172,7 @@ export default class MarinaBroker extends Broker<keyof Marina> {
   }
 
   private handleIdsParam(ids?: AccountID[]): AccountID[] {
-    if (!ids) return selectAllAccountsIDs(this.state);
+    if (!ids) return [MainAccountID];
     if (ids.length === 0) return [];
     return ids;
   }


### PR DESCRIPTION
The following provider functions will use [MainAccountID] parameter if no param has been provided by user:
* getAddresses()
* getCoins()
* getTransactions()
* reloadCoins()
* getBalances() it closes #408 

@tiero please review