### PR TITLE
Improve performance of `marina.getNextAddress`

### DIFF
--- a/src/application/redux/selectors/wallet.selector.ts
+++ b/src/application/redux/selectors/wallet.selector.ts
@@ -6,10 +6,11 @@ import type {
 } from '../../../domain/account';
 import { AccountType, accountFromMnemonicAndData, MainAccountID } from '../../../domain/account';
 import { decodePset } from 'ldk';
-import type { NetworkString, Outpoint, UnblindedOutput } from 'ldk';
+import type { NetworkString, Outpoint, UnblindedOutput, StateRestorerOpts } from 'ldk';
 import type { RootReducerState } from '../../../domain/common';
 import type { TxDisplayInterface, UtxosAndTxs } from '../../../domain/transaction';
 import { toStringOutpoint } from '../../utils/utxos';
+import { selectNetwork } from './app.selector';
 
 export const selectUtxos =
   (...accounts: AccountID[]) =>
@@ -164,3 +165,10 @@ export const selectEncryptedMnemonic = (state: RootReducerState) => {
 export const selectChangeAccount = (state: RootReducerState) => {
   return selectAccount(state.app.changeAccount)(state);
 };
+
+export function selectRestorerOpts<T extends StateRestorerOpts>(account: AccountID) {
+  return (state: RootReducerState): T => {
+    const net = selectNetwork(state);
+    return state.wallet.accounts[account].restorerOpts[net];
+  };
+}

--- a/src/content/marina/marinaBroker.ts
+++ b/src/content/marina/marinaBroker.ts
@@ -22,6 +22,7 @@ import {
   selectAllAccounts,
   selectAllAccountsIDs,
   selectMainAccount,
+  selectRestorerOpts,
   selectTransactions,
   selectUtxos,
 } from '../../application/redux/selectors/wallet.selector';
@@ -44,7 +45,7 @@ import type {
 import type { SignTransactionPopupResponse } from '../../presentation/connect/sign-pset';
 import type { SpendPopupResponse } from '../../presentation/connect/spend';
 import type { SignMessagePopupResponse } from '../../presentation/connect/sign-msg';
-import type { AccountID } from '../../domain/account';
+import type { AccountID, CustomScriptAccount, MnemonicAccount } from '../../domain/account';
 import { AccountType, MainAccountID } from '../../domain/account';
 import type { AddressInterface, UnblindedOutput } from 'ldk';
 import { getAsset, getSats } from 'ldk';
@@ -228,19 +229,41 @@ export default class MarinaBroker extends Broker<keyof Marina> {
             throw new Error('Only custom script accounts can expect construct parameters');
           }
           const net = selectNetwork(this.state);
-          const watchOnlyIdentity = await account.getWatchIdentity(net);
           let nextAddress: AddressInterface;
-          let constructorParams: Record<string, string | number> | undefined;
-          if (account.type === AccountType.MainAccount) {
-            nextAddress = await watchOnlyIdentity.getNextAddress();
-          } else {
-            if (params && params.length > 0) {
-              constructorParams = params[0];
+          const restorerOpts = selectRestorerOpts(this.selectedAccount)(this.state);
+          switch (account.type) {
+            case AccountType.CustomScriptAccount: {
+              const watchOnlyIdentity = (
+                account as CustomScriptAccount
+              ).getNotRestoredWatchIdentity(net);
+              nextAddress = watchOnlyIdentity.getAddress(
+                false,
+                restorerOpts.lastUsedExternalIndex ?? 0,
+                params?.[0]
+              );
+              break;
             }
-            nextAddress = await watchOnlyIdentity.getNextAddress(constructorParams);
+
+            case AccountType.MainAccount: {
+              const watchOnlyIdentity = (account as MnemonicAccount).getNotRestoredWatchIdentity(
+                net
+              );
+              nextAddress = watchOnlyIdentity.getAddress(
+                false,
+                restorerOpts.lastUsedExternalIndex ?? 0
+              ).address;
+              break;
+            }
+
+            default: {
+              const watchOnlyIdentity = await account.getWatchIdentity(net);
+              nextAddress = await watchOnlyIdentity.getNextAddress(params?.[0]);
+              break;
+            }
           }
+
           await Promise.all(
-            updateToNextAddress(account.getInfo().accountID, net, constructorParams).map(
+            updateToNextAddress(account.getInfo().accountID, net, params?.[0]).map(
               (action: AnyAction) => this.store?.dispatchAsync(action)
             )
           );
@@ -253,20 +276,44 @@ export default class MarinaBroker extends Broker<keyof Marina> {
           if (params && params.length > 0 && account.type !== AccountType.CustomScriptAccount) {
             throw new Error('Only custom script accounts can expect construct parameters');
           }
+
           const net = selectNetwork(this.state);
-          const xpub = await account.getWatchIdentity(net);
+          const restorerOpts = selectRestorerOpts(this.selectedAccount)(this.state);
           let nextChangeAddress: AddressInterface;
-          let constructorParams: Record<string, string | number> | undefined;
-          if (account.type === AccountType.MainAccount) {
-            nextChangeAddress = await xpub.getNextChangeAddress();
-          } else {
-            if (params && params.length > 0) {
-              constructorParams = params[0];
+
+          switch (account.type) {
+            case AccountType.CustomScriptAccount: {
+              const watchOnlyIdentity = (
+                account as CustomScriptAccount
+              ).getNotRestoredWatchIdentity(net);
+              nextChangeAddress = watchOnlyIdentity.getAddress(
+                true,
+                restorerOpts.lastUsedInternalIndex ?? 0,
+                params?.[0]
+              );
+              break;
             }
-            nextChangeAddress = await xpub.getNextChangeAddress(constructorParams);
+
+            case AccountType.MainAccount: {
+              const watchOnlyIdentity = (account as MnemonicAccount).getNotRestoredWatchIdentity(
+                net
+              );
+              nextChangeAddress = watchOnlyIdentity.getAddress(
+                true,
+                restorerOpts.lastUsedInternalIndex ?? 0
+              ).address;
+              break;
+            }
+
+            default: {
+              const watchOnlyIdentity = await account.getWatchIdentity(net);
+              nextChangeAddress = await watchOnlyIdentity.getNextChangeAddress(params?.[0]);
+              break;
+            }
           }
+
           await Promise.all(
-            updateToNextChangeAddress(account.getInfo().accountID, net, constructorParams).map(
+            updateToNextChangeAddress(account.getInfo().accountID, net, params?.[0]).map(
               (action: AnyAction) => this.store?.dispatchAsync(action)
             )
           );

--- a/src/content/marina/marinaBroker.ts
+++ b/src/content/marina/marinaBroker.ts
@@ -238,7 +238,7 @@ export default class MarinaBroker extends Broker<keyof Marina> {
               ).getNotRestoredWatchIdentity(net);
               nextAddress = watchOnlyIdentity.getAddress(
                 false,
-                restorerOpts.lastUsedExternalIndex ?? 0,
+                increment(restorerOpts.lastUsedExternalIndex),
                 params?.[0]
               );
               break;
@@ -250,7 +250,7 @@ export default class MarinaBroker extends Broker<keyof Marina> {
               );
               nextAddress = watchOnlyIdentity.getAddress(
                 false,
-                restorerOpts.lastUsedExternalIndex ?? 0
+                increment(restorerOpts.lastUsedExternalIndex)
               ).address;
               break;
             }
@@ -288,7 +288,7 @@ export default class MarinaBroker extends Broker<keyof Marina> {
               ).getNotRestoredWatchIdentity(net);
               nextChangeAddress = watchOnlyIdentity.getAddress(
                 true,
-                restorerOpts.lastUsedInternalIndex ?? 0,
+                increment(restorerOpts.lastUsedInternalIndex),
                 params?.[0]
               );
               break;
@@ -300,7 +300,7 @@ export default class MarinaBroker extends Broker<keyof Marina> {
               );
               nextChangeAddress = watchOnlyIdentity.getAddress(
                 true,
-                restorerOpts.lastUsedInternalIndex ?? 0
+                increment(restorerOpts.lastUsedInternalIndex)
               ).address;
               break;
             }
@@ -621,3 +621,8 @@ function toProviderAddress(addr: AddressInterface): ProviderAddressInterface {
 
   return result;
 }
+const increment = (n: number | undefined): number => {
+  if (n === undefined || n === null || n === -1) return 0;
+  if (n < 0) return 1; // -Infinity = 0, return 0+1=1
+  return n + 1;
+};

--- a/src/domain/account.ts
+++ b/src/domain/account.ts
@@ -21,6 +21,7 @@ import type {
   CustomScriptIdentityWatchOnly,
 } from './customscript-identity';
 import {
+  newCustomScriptWatchOnlyIdentity,
   restoredCustomScriptIdentity,
   restoredCustomScriptWatchOnlyIdentity,
 } from './customscript-identity';
@@ -53,6 +54,7 @@ export interface Account<
   type: AccountType;
   getSigningIdentity(password: string, network: NetworkString): Promise<SignID>;
   getWatchIdentity(network: NetworkString): Promise<WatchID>;
+  getNotRestoredWatchIdentity(network: NetworkString): WatchID;
   getInfo(): AccountInfoType;
 }
 
@@ -112,6 +114,8 @@ function createMainAccount(
         data.restorerOpts[network],
         network
       ),
+    getNotRestoredWatchIdentity: (network: NetworkString) =>
+      newMasterPublicKey(data.masterXPub, data.masterBlindingKey, network),
     getDeepRestorer: (network: NetworkString) => {
       const pubkey = newMasterPublicKey(data.masterXPub, data.masterBlindingKey, network);
       return makeRestorerFromChainAPI<MasterPublicKey>(
@@ -150,6 +154,13 @@ function createCustomScriptAccount(
         data.masterBlindingKey,
         network,
         data.restorerOpts[network]
+      ),
+    getNotRestoredWatchIdentity: (network: NetworkString) =>
+      newCustomScriptWatchOnlyIdentity(
+        data.masterXPub,
+        data.masterBlindingKey,
+        data.contractTemplate,
+        network
       ),
     getInfo: () => ({
       accountID: data.contractTemplate?.namespace ?? '',

--- a/src/domain/customscript-identity.ts
+++ b/src/domain/customscript-identity.ts
@@ -502,6 +502,24 @@ export function restoredCustomScriptIdentity(
   )(restorerOpts);
 }
 
+export function newCustomScriptWatchOnlyIdentity(
+  masterPublicKey: string,
+  masterBlindingKey: string,
+  contractTemplate: ContractTemplate,
+  network: NetworkString
+): CustomScriptIdentityWatchOnly {
+  return new CustomScriptIdentityWatchOnly({
+    type: IdentityType.MasterPublicKey,
+    chain: network,
+    ecclib: ecc,
+    opts: {
+      ...contractTemplate,
+      masterPublicKey,
+      masterBlindingKey,
+    },
+  });
+}
+
 export function restoredCustomScriptWatchOnlyIdentity(
   contractTemplate: ContractTemplate,
   masterPublicKey: string,
@@ -510,16 +528,7 @@ export function restoredCustomScriptWatchOnlyIdentity(
   restorerOpts: CustomRestorerOpts
 ): Promise<CustomScriptIdentityWatchOnly> {
   return customRestorerFromState<CustomScriptIdentityWatchOnly>(
-    new CustomScriptIdentityWatchOnly({
-      type: IdentityType.MasterPublicKey,
-      chain: network,
-      ecclib: ecc,
-      opts: {
-        ...contractTemplate,
-        masterPublicKey,
-        masterBlindingKey,
-      },
-    })
+    newCustomScriptWatchOnlyIdentity(masterPublicKey, masterBlindingKey, contractTemplate, network)
   )(restorerOpts);
 }
 


### PR DESCRIPTION
This PR improves the way marina provider is generating the account next addresses (getNext*Address functions)

The idea is to **stop restore from state** before generating the next address. Instead we get the last index and generate only that address (the former ones are not used in fact). This improvement lets to have constant execution time for `marina.getNext*Address` call (~25ms whatever the number of addresses in wallet).

it closes #405 (@ErikDeSmedt if u can test on your own app)

@tiero please review