### PR TITLE
Rework the memorized transaction routing logic

### DIFF
--- a/src/presentation/components/address-amount-form.tsx
+++ b/src/presentation/components/address-amount-form.tsx
@@ -10,7 +10,6 @@ import {
 import { createAddress } from '../../domain/address';
 import { SEND_CHOOSE_FEE_ROUTE } from '../routes/constants';
 import * as Yup from 'yup';
-import type { TransactionState } from '../../application/redux/reducers/transaction-reducer';
 import type { Asset } from '../../domain/assets';
 import { updateToNextChangeAddress } from '../../application/redux/actions/wallet';
 import type { Account } from '../../domain/account';
@@ -33,7 +32,8 @@ interface AddressAmountFormProps {
   dispatch: ProxyStoreDispatch;
   asset: Asset;
   history: RouteComponentProps['history'];
-  transaction: TransactionState;
+  address: string;
+  amount: number;
   network: NetworkString;
   account: Account;
 }
@@ -83,7 +83,7 @@ const AddressAmountForm = (props: FormikProps<AddressAmountFormValues>) => {
   return (
     <form onSubmit={handleSubmit} className="mt-8">
       <p className="mb-2 text-base font-medium text-left">Address</p>
-      <Input name="address" placeholder="" type="text" {...props} />
+      <Input {...props} name="address" placeholder="" type="text" value={values.address} />
 
       <div className="flex content-center justify-between mb-2">
         <p className="text-base font-medium text-left">Amount</p>
@@ -129,13 +129,16 @@ const AddressAmountForm = (props: FormikProps<AddressAmountFormValues>) => {
 
 const AddressAmountEnhancedForm = withFormik<AddressAmountFormProps, AddressAmountFormValues>({
   mapPropsToValues: (props: AddressAmountFormProps): AddressAmountFormValues => ({
-    address: props.transaction.sendAddress?.value ?? '',
+    address: props.address,
     // Little hack to initialize empty value of type number
     // https://github.com/formium/formik/issues/321#issuecomment-478364302
     amount:
-      props.transaction.sendAmount > 0
-        ? sanitizeInputAmount((props.transaction.sendAmount ?? 0).toString(), props.asset.precision)
-        : '',
+      props.amount <= 0
+        ? ''
+        : sanitizeInputAmount(
+            fromSatoshi(props.amount ?? 0, props.asset.precision).toString(),
+            props.asset.precision
+          ),
     assetTicker: props.asset.ticker ?? '??',
     assetPrecision: props.asset.precision,
     balance: fromSatoshi(props.balance ?? 0, props.asset.precision),

--- a/src/presentation/components/shell-popup.tsx
+++ b/src/presentation/components/shell-popup.tsx
@@ -53,9 +53,9 @@ const ShellPopUp: React.FC<Props> = ({
       const makeUpdateTaskForId = (id: AccountID) => updateTaskAction(id, network);
       await Promise.all(allAccountsIds.map(makeUpdateTaskForId).map(dispatch));
     } else {
+      await dispatch(flushPendingTx());
       history.push(DEFAULT_ROUTE);
     }
-    await dispatch(flushPendingTx());
   };
   const handleBackBtn = () => {
     if (backBtnCb) {

--- a/src/presentation/routes/guards.tsx
+++ b/src/presentation/routes/guards.tsx
@@ -2,23 +2,29 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import type { RouteProps, RouteComponentProps } from 'react-router-dom';
 import { Route, Redirect, useParams } from 'react-router-dom';
+import type { PendingTxStep } from '../../application/redux/reducers/transaction-reducer';
 import type { RootReducerState } from '../../domain/common';
-import { CONNECT_ENABLE_ROUTE, CONNECT_SPEND_ROUTE } from './constants';
+import {
+  CONNECT_ENABLE_ROUTE,
+  CONNECT_SPEND_ROUTE,
+  SEND_ADDRESS_AMOUNT_ROUTE,
+  SEND_CHOOSE_FEE_ROUTE,
+  SEND_CONFIRMATION_ROUTE,
+} from './constants';
 
 const ALLOWED_REDIRECT_ROUTE = [CONNECT_ENABLE_ROUTE, CONNECT_SPEND_ROUTE];
-
-/**
- * A wrapper for <Route> that redirects to the login screen if you're not yet authenticated
- *
- * @param comp A route component
- * @param rest The rest of props
- * @returns A route component
- */
 
 interface ProtectedRouteProps extends RouteProps {
   component: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<any>;
 }
 
+/**
+ * A wrapper for <Route> that redirects to the login screen if you're not yet authenticated
+ *
+ * @param component A route component
+ * @param rest The rest of Route props
+ * @returns A route component
+ */
 export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
   component: Component,
   ...rest
@@ -49,6 +55,51 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
           />
         )
       }
+    />
+  );
+};
+
+/**
+ * like ProtectedRoute but with redirect logic in case of transaction step
+ */
+export const ProtectedRedirectRoute: React.FC<ProtectedRouteProps> = ({
+  component: Component,
+  ...rest
+}) => {
+  const transactionStep = useSelector((state: RootReducerState) => state.transaction.step);
+  const isAuthenticated = useSelector((state: RootReducerState) => state.app.isAuthenticated);
+
+  const stepToPathName = (step: PendingTxStep) => {
+    switch (step) {
+      case 'address-amount':
+        return SEND_ADDRESS_AMOUNT_ROUTE;
+      case 'choose-fee':
+        return SEND_CHOOSE_FEE_ROUTE;
+      case 'confirmation':
+        return SEND_CONFIRMATION_ROUTE;
+    }
+  };
+
+  return (
+    <Route
+      {...rest}
+      render={(props) => {
+        if (!isAuthenticated) {
+          return (
+            <Redirect
+              to={{
+                pathname: '/login',
+                state: { from: props.location },
+              }}
+            />
+          );
+        }
+        const transactionPath = stepToPathName(transactionStep);
+        if (transactionPath) {
+          return <Redirect to={{ pathname: transactionPath }} />;
+        }
+        return <Component {...props} />;
+      }}
     />
   );
 };

--- a/src/presentation/routes/index.tsx
+++ b/src/presentation/routes/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Switch, Route } from 'react-router-dom';
-import { ProtectedRoute } from './guards';
+import { Switch, Route } from 'react-router';
+import { ProtectedRedirectRoute, ProtectedRoute } from './guards';
 import {
   CONNECT_ENABLE_ROUTE,
   CONNECT_SPEND_ROUTE,
@@ -98,8 +98,9 @@ const Routes: React.FC = () => {
       <Route exact path={INITIALIZE_END_OF_FLOW_ROUTE} component={EndOfFlow} />
       <Route exact path={RESTORE_VAULT_ROUTE} component={WalletRestore} />
       <Route exact path={BACKUP_UNLOCK_ROUTE} component={BackUpUnlock} />
+
       {/*Wallet*/}
-      <ProtectedRoute exact path={DEFAULT_ROUTE} component={Home} />
+      <ProtectedRedirectRoute exact path={DEFAULT_ROUTE} component={Home} />
       <ProtectedRoute exact path={TRANSACTIONS_ROUTE} component={Transactions} />
       <ProtectedRoute exact path={RECEIVE_SELECT_ASSET_ROUTE} component={ReceiveSelectAsset} />
       <ProtectedRoute exact path={`${RECEIVE_ADDRESS_ROUTE}/:asset`} component={ReceiveView} />

--- a/src/presentation/wallet/send/address-amount.tsx
+++ b/src/presentation/wallet/send/address-amount.tsx
@@ -55,8 +55,9 @@ const AddressAmountView: React.FC<AddressAmountProps> = ({
         dispatch={dispatch}
         history={history}
         balance={balances[transaction.sendAsset] ?? 0}
-        transaction={transaction}
         network={network}
+        amount={transaction.sendAmount || 0}
+        address={transaction.sendAddress?.value || ''}
         asset={transactionAsset}
         account={changeAccount}
       />

--- a/src/presentation/wallet/send/choose-fee.tsx
+++ b/src/presentation/wallet/send/choose-fee.tsx
@@ -20,7 +20,6 @@ import type { IAssets } from '../../../domain/assets';
 import { useDispatch } from 'react-redux';
 import type { BalancesByAsset } from '../../../application/redux/selectors/balance.selector';
 import {
-  flushPendingTx,
   setFeeAssetAndAmount,
   setFeeChangeAddress,
   setPendingTxStep,
@@ -75,18 +74,6 @@ const ChooseFeeView: React.FC<ChooseFeeProps> = ({
 }) => {
   const history = useHistory();
   const dispatch = useDispatch<ProxyStoreDispatch>();
-
-  useEffect(() => {
-    if (!changeAddress?.value || !sendAddress?.value || !sendAsset) {
-      dispatch(flushPendingTx()).catch(console.error);
-      history.goBack();
-    } else {
-      dispatch(setPendingTxStep('choose-fee')).catch(console.error);
-    }
-    return () => {
-      setFeeAsset(lbtcAssetHash);
-    };
-  }, []);
 
   const [state, setState] = useState(initialState);
   const [feeAsset, setFeeAsset] = useState<string | undefined>(undefined);
@@ -357,7 +344,7 @@ function actionsFromState(
   const actions: AnyAction[] = [];
   const feeAmount = state.topup ? state.topup.assetAmount : feeAmountFromTx(state.unsignedPset);
   actions.push(setPset(state.unsignedPset, state.utxos));
-  actions.push(setPendingTxStep('confirmation'));
+  actions.push(setPendingTxStep('choose-fee'));
   actions.push(setFeeAssetAndAmount(feeCurrency, feeAmount));
 
   if (state.feeChange) {


### PR DESCRIPTION
This PR is reworking the way we memorize the routing logic of send pages.

* drop several `useEffect` handling history.goBack & history.push
* replace useEffect by a new `ProtectedRedirectRoute` applied to homepage (route `/`). That component works like ProtectedRoute but redirect to the right send page depending on the `state.transaction.step` value.

it closes #418 

@tiero please review