### PR TITLE
Fix inconsistency on buttons layout

### DIFF
--- a/src/presentation/components/buttons-at-bottom.tsx
+++ b/src/presentation/components/buttons-at-bottom.tsx
@@ -5,7 +5,7 @@ interface Props {
 }
 
 const ButtonsAtBottom: React.FC<Props> = ({ children }: Props) => {
-  return <div className="bottom-10 right-8 absolute flex justify-end gap-1">{children}</div>;
+  return <div className="bottom-14 right-8 absolute flex justify-end gap-1">{children}</div>;
 };
 
 export default ButtonsAtBottom;

--- a/src/presentation/components/buttons-at-bottom.tsx
+++ b/src/presentation/components/buttons-at-bottom.tsx
@@ -5,7 +5,9 @@ interface Props {
 }
 
 const ButtonsAtBottom: React.FC<Props> = ({ children }: Props) => {
-  return <div className="bottom-14 right-8 absolute flex justify-end gap-1">{children}</div>;
+  let cN = 'bottom-14 right-0 container absolute flex ';
+  cN += React.Children.count(children) > 1 ? 'justify-between' : 'justify-end';
+  return <div className={cN}>{children}</div>;
 };
 
 export default ButtonsAtBottom;

--- a/src/presentation/components/buttons-at-bottom.tsx
+++ b/src/presentation/components/buttons-at-bottom.tsx
@@ -5,7 +5,7 @@ interface Props {
 }
 
 const ButtonsAtBottom: React.FC<Props> = ({ children }: Props) => {
-  return <div className="bottom-10 right-8 absolute flex justify-end">{children}</div>;
+  return <div className="bottom-10 right-8 absolute flex justify-end gap-1">{children}</div>;
 };
 
 export default ButtonsAtBottom;

--- a/src/presentation/components/buttons-at-bottom.tsx
+++ b/src/presentation/components/buttons-at-bottom.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+interface Props {
+  children: React.ReactElement | React.ReactElement[];
+}
+
+const ButtonsAtBottom: React.FC<Props> = ({ children }: Props) => {
+  return <div className="bottom-10 right-8 absolute flex justify-end">{children}</div>;
+};
+
+export default ButtonsAtBottom;

--- a/src/presentation/components/explorer-custom-form.tsx
+++ b/src/presentation/components/explorer-custom-form.tsx
@@ -1,6 +1,5 @@
 import type { FormikProps } from 'formik';
 import { withFormik } from 'formik';
-import React from 'react';
 import { setExplorer } from '../../application/redux/actions/app';
 import type { ProxyStoreDispatch } from '../../application/redux/proxyStore';
 import Button from './button';
@@ -8,6 +7,7 @@ import Input from './input';
 import * as Yup from 'yup';
 import type { NetworkString } from 'ldk';
 import type { ExplorerURLs } from '../../domain/app';
+import ButtonsAtBottom from './buttons-at-bottom';
 
 type SettingsExplorerFormValues = ExplorerURLs & {
   network: NetworkString;
@@ -35,18 +35,16 @@ const SettingsExplorerForm = (props: FormikProps<SettingsExplorerFormValues>) =>
       <p className="font-sm text-left">Batch Electrs URL</p>
       <Input name="batchServerURL" placeholder="Electrs batch server" type="text" {...props} />
 
-      <div className="bottom-15 right-8 absolute flex justify-end">
-        <div>
-          <Button
-            disabled={
-              !!errors.esploraURL || !!errors.electrsURL || !!errors.batchServerURL || isSubmitting
-            }
-            type="submit"
-          >
-            Update
-          </Button>
-        </div>
-      </div>
+      <ButtonsAtBottom>
+        <Button
+          disabled={
+            !!errors.esploraURL || !!errors.electrsURL || !!errors.batchServerURL || isSubmitting
+          }
+          type="submit"
+        >
+          Update
+        </Button>
+      </ButtonsAtBottom>
     </form>
   );
 };

--- a/src/presentation/components/modal-unlock.tsx
+++ b/src/presentation/components/modal-unlock.tsx
@@ -6,6 +6,7 @@ import Button from './button';
 import Input from './input';
 import Modal from './modal';
 import { debounce } from 'lodash';
+import ButtonsAtBottom from './buttons-at-bottom';
 
 interface ModalUnlockFormValues {
   handleModalUnlockClose(): void;
@@ -27,22 +28,18 @@ const ModalUnlockForm = (props: FormikProps<ModalUnlockFormValues>) => {
         <p className="mt-10 mb-5 text-base text-left">Enter your password to unlock your wallet</p>
         <Input name="password" placeholder="Password" type="password" {...props} />
       </div>
-      <div className="bottom-10 right-8 absolute flex justify-end">
-        <div className="pr-1">
-          <Button
-            isOutline={true}
-            onClick={() => values.handleModalUnlockClose()}
-            className="bg-secondary hover:bg-secondary-light"
-          >
-            Cancel
-          </Button>
-        </div>
-        <div>
-          <Button type="submit" disabled={isSubmitting}>
-            {!isSubmitting ? `Unlock` : `Please wait...`}
-          </Button>
-        </div>
-      </div>
+      <ButtonsAtBottom>
+        <Button
+          isOutline={true}
+          onClick={() => values.handleModalUnlockClose()}
+          className="bg-secondary hover:bg-secondary-light"
+        >
+          Cancel
+        </Button>
+        <Button type="submit" disabled={isSubmitting}>
+          {!isSubmitting ? `Unlock` : `Please wait...`}
+        </Button>
+      </ButtonsAtBottom>
     </form>
   );
 };

--- a/src/presentation/connect/create-account.tsx
+++ b/src/presentation/connect/create-account.tsx
@@ -16,6 +16,7 @@ import ModalUnlock from '../components/modal-unlock';
 import ShellConnectPopup from '../components/shell-connect-popup';
 import PopupWindowProxy from './popupWindowProxy';
 import * as ecc from 'tiny-secp256k1';
+import ButtonsAtBottom from '../components/buttons-at-bottom';
 
 export interface CreateAccountPopupResponse {
   accepted: boolean;
@@ -106,14 +107,14 @@ const ConnectCreateAccount: React.FC<WithConnectDataProps> = ({ connectData }) =
             <b>namespace:</b> {connectData.createAccount?.namespace}. <br />
           </p>
 
-          <div className="bottom-24 container absolute right-0 flex justify-between">
+          <ButtonsAtBottom>
             <Button isOutline={true} onClick={rejectSignRequest} textBase={true}>
               Reject
             </Button>
             <Button onClick={handleUnlockModalOpen} textBase={true}>
               Accept
             </Button>
-          </div>
+          </ButtonsAtBottom>
         </>
       ) : (
         <>

--- a/src/presentation/connect/enable.tsx
+++ b/src/presentation/connect/enable.tsx
@@ -9,6 +9,7 @@ import { enableWebsite, flushSelectedHostname } from '../../application/redux/ac
 import type { RootReducerState } from '../../domain/common';
 import { debounce } from 'lodash';
 import PopupWindowProxy from './popupWindowProxy';
+import ButtonsAtBottom from '../components/buttons-at-bottom';
 
 const permissions = ['View confidential addresses of your wallet', 'View balances of your wallet'];
 
@@ -61,14 +62,14 @@ const ConnectEnableView: React.FC<WithConnectDataProps> = ({ connectData }) => {
         </div>
       ))}
 
-      <div className="bottom-12 container absolute right-0 flex justify-between">
+      <ButtonsAtBottom>
         <Button isOutline={true} onClick={handleReject} textBase={true}>
           Reject
         </Button>
         <Button onClick={debouncedHandleConnect} textBase={true}>
           Connect
         </Button>
-      </div>
+      </ButtonsAtBottom>
     </ShellConnectPopup>
   );
 };

--- a/src/presentation/connect/sign-msg.tsx
+++ b/src/presentation/connect/sign-msg.tsx
@@ -16,6 +16,7 @@ import {
   SOMETHING_WENT_WRONG_ERROR,
 } from '../../application/utils/constants';
 import { decrypt } from '../../application/utils/crypto';
+import ButtonsAtBottom from '../components/buttons-at-bottom';
 
 function signMsgWithPassword(
   message: string,
@@ -101,14 +102,14 @@ const ConnectSignMsg: React.FC<WithConnectDataProps> = ({ connectData }) => {
 
           <p className="text-small mt-2 font-medium"> {connectData.msg?.message}</p>
 
-          <div className="bottom-24 container absolute right-0 flex justify-between">
+          <ButtonsAtBottom>
             <Button isOutline={true} onClick={handleReject} textBase={true}>
               Reject
             </Button>
             <Button onClick={handleUnlockModalOpen} textBase={true}>
               Accept
             </Button>
-          </div>
+          </ButtonsAtBottom>
         </>
       ) : (
         <>

--- a/src/presentation/connect/sign-pset.tsx
+++ b/src/presentation/connect/sign-pset.tsx
@@ -10,6 +10,7 @@ import PopupWindowProxy from './popupWindowProxy';
 import { signPset } from '../../application/utils/transaction';
 import { SOMETHING_WENT_WRONG_ERROR } from '../../application/utils/constants';
 import { selectNetwork } from '../../application/redux/selectors/app.selector';
+import ButtonsAtBottom from '../components/buttons-at-bottom';
 
 export interface SignTransactionPopupResponse {
   accepted: boolean;
@@ -82,14 +83,14 @@ const ConnectSignTransaction: React.FC<WithConnectDataProps> = ({ connectData })
             <b>WARNING</b> This transaction could potentially spend all of your funds.
           </p>
 
-          <div className="bottom-24 container absolute right-0 flex justify-between">
+          <ButtonsAtBottom>
             <Button isOutline={true} onClick={rejectSignRequest} textBase={true}>
               Reject
             </Button>
             <Button onClick={handleUnlockModalOpen} textBase={true}>
               Accept
             </Button>
-          </div>
+          </ButtonsAtBottom>
         </>
       ) : (
         <>

--- a/src/presentation/connect/spend.tsx
+++ b/src/presentation/connect/spend.tsx
@@ -30,6 +30,7 @@ import { selectNetwork } from '../../application/redux/selectors/app.selector';
 import { lbtcAssetByNetwork } from '../../application/utils/network';
 import { Transaction } from 'liquidjs-lib';
 import type { UnconfirmedOutput } from '../../domain/unconfirmed';
+import ButtonsAtBottom from '../components/buttons-at-bottom';
 
 export interface SpendPopupResponse {
   accepted: boolean;
@@ -171,14 +172,14 @@ const ConnectSpend: React.FC<WithConnectDataProps> = ({ connectData }) => {
             ))}
           </div>
 
-          <div className="bottom-12 container absolute right-0 flex justify-between">
+          <ButtonsAtBottom>
             <Button isOutline={true} onClick={handleReject} textBase={true}>
               Reject
             </Button>
             <Button onClick={handleUnlockModalOpen} textBase={true}>
               Accept
             </Button>
-          </div>
+          </ButtonsAtBottom>
         </>
       ) : (
         <div className="flex flex-col justify-center p-2 align-middle">

--- a/src/presentation/settings/change-password.tsx
+++ b/src/presentation/settings/change-password.tsx
@@ -10,6 +10,7 @@ import Input from '../components/input';
 import { DEFAULT_ROUTE } from '../routes/constants';
 import { useDispatch } from 'react-redux';
 import type { ProxyStoreDispatch } from '../../application/redux/proxyStore';
+import ButtonsAtBottom from '../components/buttons-at-bottom';
 
 interface SettingsChangePasswordFormValues {
   currentPassword: string;
@@ -50,33 +51,28 @@ const SettingsChangePasswordForm = (props: FormikProps<SettingsChangePasswordFor
         type="password"
         {...props}
       />
-
-      <div className="flex justify-end">
-        <div className="pr-1">
-          <Button
-            isOutline={true}
-            onClick={handleCancel}
-            className="bg-secondary hover:bg-secondary-light"
-          >
-            Cancel
-          </Button>
-        </div>
-        <div>
-          <Button
-            disabled={
-              isSubmitting ||
-              !!(
-                (errors.currentPassword && touched.currentPassword) ||
-                (errors.newPassword && touched.newPassword) ||
-                (errors.confirmNewPassword && touched.confirmNewPassword)
-              )
-            }
-            type="submit"
-          >
-            Update
-          </Button>
-        </div>
-      </div>
+      <ButtonsAtBottom>
+        <Button
+          isOutline={true}
+          onClick={handleCancel}
+          className="bg-secondary hover:bg-secondary-light"
+        >
+          Cancel
+        </Button>
+        <Button
+          disabled={
+            isSubmitting ||
+            !!(
+              (errors.currentPassword && touched.currentPassword) ||
+              (errors.newPassword && touched.newPassword) ||
+              (errors.confirmNewPassword && touched.confirmNewPassword)
+            )
+          }
+          type="submit"
+        >
+          Update
+        </Button>
+      </ButtonsAtBottom>
     </form>
   );
 };
@@ -94,13 +90,13 @@ const SettingsChangePasswordEnhancedForm = withFormik<
   validationSchema: Yup.object().shape({
     currentPassword: Yup.string()
       .required('Please input password')
-      .min(8, 'Password is too short - should be 8 chars minimum.'),
+      .min(8, 'Password is too short, must be 8 chars or more'),
     newPassword: Yup.string()
       .required('Please input password')
-      .min(8, 'Password is too short - should be 8 chars minimum.'),
+      .min(8, 'Password is too short, must be 8 chars or more'),
     confirmNewPassword: Yup.string()
       .required('Please confirm password')
-      .min(8, 'Password is too short - should be 8 chars minimum.')
+      .min(8, 'Password is too short, must be 8 chars or more')
       .oneOf([Yup.ref('newPassword'), null], 'Passwords must match'),
   }),
 

--- a/src/presentation/settings/deep-restorer.tsx
+++ b/src/presentation/settings/deep-restorer.tsx
@@ -7,6 +7,7 @@ import { setDeepRestorerGapLimit } from '../../application/redux/actions/wallet'
 import Button from '../components/button';
 import type { AccountID } from '../../domain/account';
 import { restoreTaskAction } from '../../application/redux/actions/task';
+import ButtonsAtBottom from '../components/buttons-at-bottom';
 
 export interface DeepRestorerProps {
   restorationLoading: boolean;
@@ -48,18 +49,13 @@ const SettingsDeepRestorerView: React.FC<DeepRestorerProps> = ({
           );
         }}
       />
-
-      <Button
-        className={'m-2'}
-        disabled={restorationLoading || isLoading}
-        onClick={onClickRestore}
-        type="submit"
-      >
-        Restore
-      </Button>
-
       {restorationLoading && <p className="m-2">{'restoration loading'}...</p>}
       {error && <p className="m-2">{error}</p>}
+      <ButtonsAtBottom>
+        <Button disabled={restorationLoading || isLoading} onClick={onClickRestore} type="submit">
+          Restore
+        </Button>
+      </ButtonsAtBottom>
     </ShellPopUp>
   );
 };

--- a/src/presentation/settings/explorer.tsx
+++ b/src/presentation/settings/explorer.tsx
@@ -15,7 +15,6 @@ import {
 import type { NetworkString } from 'ldk';
 import { useHistory } from 'react-router';
 import { SETTINGS_EXPLORER_CUSTOM_ROUTE } from '../routes/constants';
-import Button from '../components/button';
 
 export interface SettingsExplorerProps {
   currentExplorerURLs: ExplorerURLs;
@@ -67,7 +66,7 @@ const SettingsExplorerView: React.FC<SettingsExplorerProps> = ({
 
   const pushToCustomForm = () => history.push(SETTINGS_EXPLORER_CUSTOM_ROUTE);
 
-  const onSelect = (newValue: string) => {
+  const onSelect = async (newValue: string) => {
     switch (newValue) {
       case 'Custom':
         pushToCustomForm();
@@ -76,6 +75,7 @@ const SettingsExplorerView: React.FC<SettingsExplorerProps> = ({
       case 'Blockstream':
       case 'Mempool':
         setSelected(newValue);
+        await handleChange(newValue);
         break;
     }
   };
@@ -93,14 +93,6 @@ const SettingsExplorerView: React.FC<SettingsExplorerProps> = ({
         onSelect={onSelect}
         disabled={false}
       />
-
-      <div className="flex justify-end mt-1">
-        <div>
-          <Button type="button" onClick={() => handleChange(selected).catch(console.error)}>
-            Update
-          </Button>
-        </div>
-      </div>
     </ShellPopUp>
   );
 };


### PR DESCRIPTION
Implements new component ButtonsAtBottom that will layout buttons on the following manner:
- 1 button => justify-end
- more then 1 button => justify-between

Uses new ButtonsAtBottom component on:
- src/presentation/components/explorer-custom-form.tsx
- src/presentation/components/modal-unlock.tsx
- src/presentation/connect/create-account.tsx
- src/presentation/connect/enable.tsx
- src/presentation/connect/sign-msg.tsx
- src/presentation/connect/sign-pset.tsx
- src/presentation/connect/spend.tsx
- src/presentation/settings/change-password.tsx
- src/presentation/settings/deep-restorer.tsx
- src/presentation/settings/explorer.tsx (on custom option)

Also:
- Removes button 'Update' on src/presentation/settings/explorer.tsx

Closes #429 

@tiero please review
