### PR TITLE
Fix error when importing template to Marina

### DIFF
--- a/src/content/marina/marinaBroker.ts
+++ b/src/content/marina/marinaBroker.ts
@@ -490,7 +490,7 @@ export default class MarinaBroker extends Broker<keyof Marina> {
             }
             contract = params[0];
 
-            if (params.length > 1) {
+            if (params[1]) {
               if (!validateTemplate(params[1])) {
                 throw new Error('Invalid change template');
               }


### PR DESCRIPTION
App is calling marina importTemplate like this:

```
await marina.importTemplate({
  type: 'ionio-artifact',
  template: JSON.stringify(synthAssetArtifact),
})
```

On marina is received by provider, which adds an undefined field to array (`changeTemplate`)

https://github.com/vulpemventures/marina/blob/e91d805c50bc14a8f9ba70511d85f1d7221a5cc8/src/inject/marina/provider.ts#L45-L47

So, params has a length of 2 when the function `importTemplate` is called.
A wrong validation of params[1] on line 493 called `validateContract` with an undefined contract, which generated a throw.

https://github.com/vulpemventures/marina/blob/e08df1c73c53461d94b6434f286766c00c9e6636/src/content/marina/marinaBroker.ts#L485-L499

Changing line 493 to `if (params[1])` fixed it.

The big question is: how did this ever worked?
@tiero @louisinger 