### PR TITLE
move `useSelectTransations` logic to `StorageContext`

### DIFF
--- a/src/application/utils.ts
+++ b/src/application/utils.ts
@@ -1,14 +1,44 @@
+import type { Asset, NetworkString } from 'marina-provider';
+import { BlockstreamExplorerURLs, BlockstreamTestnetExplorerURLs } from '../domain/explorer';
+
 export function h2b(hex: string): Buffer {
   return Buffer.from(hex, 'hex');
 }
 
-export async function fetchAsset(webExplorerURL: string, asset: string) {
-  const response = await fetch(`${webExplorerURL}/api/asset/${asset}`);
-  const { name, ticker, precision } = await response.json();
-  return {
-    name: name || 'Unknown',
-    ticker: ticker || asset.substring(0, 4),
-    precision: precision ?? 8,
-    assetHash: asset,
-  };
+function getAssetEndpoint(network: NetworkString) {
+  switch (network) {
+    case 'liquid':
+      return BlockstreamExplorerURLs.webExplorerURL + '/api/asset';
+    case 'testnet':
+      return BlockstreamTestnetExplorerURLs.webExplorerURL + '/api/asset';
+    case 'regtest':
+      return 'http://localhost:3001/asset';
+    default:
+      throw new Error('Invalid network');
+  }
+}
+
+export function assetIsUnknown(asset: Asset): boolean {
+  return asset.name === 'Unknown';
+}
+
+export async function fetchAssetDetails(network: NetworkString, assetHash: string): Promise<Asset> {
+  try {
+    const response = await fetch(`${getAssetEndpoint(network)}/${assetHash}`);
+    const { name, ticker, precision } = await response.json();
+    return {
+      name: name ?? 'Unknown',
+      ticker: ticker ?? assetHash.substring(0, 4),
+      precision: precision ?? 8,
+      assetHash,
+    };
+  } catch (e) {
+    console.debug(e);
+    return {
+      name: 'Unknown',
+      ticker: assetHash.substring(0, 4),
+      precision: 8,
+      assetHash,
+    };
+  }
 }

--- a/src/domain/repository.ts
+++ b/src/domain/repository.ts
@@ -128,10 +128,11 @@ export interface WalletRepository {
     indexes: Partial<{ internal: number; external: number }>
   ): Promise<void>;
 
-  onNewTransaction: EventEmitter<[txID: string, details: TxDetails]>;
+  onNewTransaction: EventEmitter<[txID: string, details: TxDetails, network: NetworkString]>;
   onNewUtxo: (network: NetworkString) => EventEmitter<[utxo: UnblindedOutput]>;
   onDeleteUtxo: (network: NetworkString) => EventEmitter<[utxo: UnblindedOutput]>;
   onNewScript: EventEmitter<[script: string, details: ScriptDetails]>;
+  onUnblinding: EventEmitter<[outpoint: Outpoint, data: UnblindingData]>;
 }
 
 // asset registry is a local cache of remote elements-registry

--- a/src/domain/repository.ts
+++ b/src/domain/repository.ts
@@ -132,7 +132,6 @@ export interface WalletRepository {
   onNewUtxo: (network: NetworkString) => EventEmitter<[utxo: UnblindedOutput]>;
   onDeleteUtxo: (network: NetworkString) => EventEmitter<[utxo: UnblindedOutput]>;
   onNewScript: EventEmitter<[script: string, details: ScriptDetails]>;
-  onUnblinding: EventEmitter<[outpoint: Outpoint, data: UnblindingData]>;
 }
 
 // asset registry is a local cache of remote elements-registry

--- a/src/extension/components/button-transaction.tsx
+++ b/src/extension/components/button-transaction.tsx
@@ -1,18 +1,16 @@
-import React, { useEffect, useState } from 'react';
-import type { TxDetails } from '../../domain/transaction';
+import React, { useState } from 'react';
+import type { TxDetailsExtended } from '../../domain/transaction';
 import { makeURLwithBlinders, TxType } from '../../domain/transaction';
 import { formatDecimalAmount, fromSatoshi, fromSatoshiStr } from '../utility';
 import TxIcon from './txIcon';
 import moment from 'moment';
 import Modal from './modal';
-import { networks, Transaction } from 'liquidjs-lib';
+import { Transaction } from 'liquidjs-lib';
 import AssetIcon from './assetIcon';
-import { confidentialValueToSatoshi } from 'liquidjs-lib/src/confidential';
 import Button from './button';
 import Browser from 'webextension-polyfill';
 import type { Asset } from 'marina-provider';
 import { useStorageContext } from '../context/storage-context';
-import type { BlockHeader } from '../../domain/chainsource';
 
 function txTypeFromTransfer(transfer?: number): TxType {
   if (transfer === undefined) return TxType.Unknow;
@@ -22,112 +20,13 @@ function txTypeFromTransfer(transfer?: number): TxType {
 }
 
 interface Props {
-  txDetails?: TxDetails;
+  txDetails: TxDetailsExtended;
   assetSelected: Asset;
 }
 
 const ButtonTransaction: React.FC<Props> = ({ txDetails, assetSelected }) => {
-  const { walletRepository, blockHeadersRepository, appRepository } = useStorageContext();
+  const { walletRepository, appRepository } = useStorageContext();
   const [modalOpen, setModalOpen] = useState(false);
-  const [transfer, setTransfer] = useState<{ amount: number; type: TxType }>();
-  const [feeAmount, setFeeAmount] = useState<number>();
-  const [txID, setTxID] = useState<string>();
-  const [blockHeader, setBlockHeader] = useState<BlockHeader>();
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    (async () => {
-      // first of all, compute the transfer amount from blinding data and tx hex
-      if (!txDetails?.hex) return;
-      const transaction = Transaction.fromHex(txDetails.hex);
-      const txID = transaction.getId();
-      setTxID(txID);
-
-      let transferAmount = 0;
-      let lbtcFeeAmount = 0;
-
-      let hasOutputWithAnotherAsset = false;
-
-      for (let outIndex = 0; outIndex < transaction.outs.length; outIndex++) {
-        const output = transaction.outs[outIndex];
-        if (output.script.length === 0) {
-          lbtcFeeAmount = confidentialValueToSatoshi(output.value);
-          continue;
-        }
-
-        const data = await walletRepository.getOutputBlindingData(txID, outIndex);
-        if (!data || !data.blindingData) continue;
-        if (data.blindingData.asset === assetSelected.assetHash) {
-          transferAmount += data.blindingData.value;
-          continue;
-        }
-        hasOutputWithAnotherAsset = true;
-      }
-
-      const hasOutputWithSelectedAsset = transferAmount > 0;
-
-      for (let inIndex = 0; inIndex < transaction.ins.length; inIndex++) {
-        const input = transaction.ins[inIndex];
-        const data = await walletRepository.getOutputBlindingData(
-          Buffer.from(input.hash).reverse().toString('hex'),
-          input.index
-        );
-        if (!data || !data.blindingData) continue;
-        if (data.blindingData.asset === assetSelected.assetHash) {
-          transferAmount -= data.blindingData.value;
-        }
-      }
-
-      const network = await appRepository.getNetwork();
-      if (!network) return;
-
-      // ignore the tx where we don't have any output with the selected asset
-      if (!hasOutputWithSelectedAsset) {
-        setTransfer(undefined);
-        return;
-      }
-
-      if (
-        assetSelected.assetHash === networks[network].assetHash &&
-        transferAmount + lbtcFeeAmount === 0 &&
-        hasOutputWithAnotherAsset
-      ) {
-        // in case of L-BTC, ignore the tx where we only use LBTC to pay the fees
-        setTransfer(undefined);
-        return;
-      }
-
-      setTransfer({
-        amount: transferAmount,
-        type: txTypeFromTransfer(transferAmount),
-      });
-      setFeeAmount(lbtcFeeAmount);
-
-      // get the block header, if not found in repository, fetch it from the chain
-      // skip if the tx is not confirmed (height === -1)
-      if (!txDetails?.height || txDetails.height === -1) {
-        // check if the tx has been confirmed
-        setBlockHeader(undefined);
-        return;
-      }
-
-      if (blockHeader && blockHeader.height === txDetails.height) return;
-
-      let header = await blockHeadersRepository.getBlockHeader(network, txDetails.height);
-
-      if (!header) {
-        const chainSource = await appRepository.getChainSource(network);
-        if (!chainSource) return;
-        header = await chainSource.fetchBlockHeader(txDetails.height);
-        if (header) await blockHeadersRepository.setBlockHeader(network, header);
-        await chainSource.close();
-      }
-
-      setBlockHeader(header);
-    })()
-      .catch(console.error)
-      .finally(() => setIsLoading(false));
-  }, [txDetails]);
 
   const handleClick = () => {
     setModalOpen(true);
@@ -143,7 +42,9 @@ const ButtonTransaction: React.FC<Props> = ({ txDetails, assetSelected }) => {
     await Browser.tabs.create({ url, active: false });
   };
 
-  if (!transfer) return null;
+  const transferAmount = () => txDetails.txFlow[assetSelected.assetHash];
+  const transferAmountIsDefined = () => transferAmount() !== undefined;
+
   return (
     <>
       <button
@@ -152,15 +53,11 @@ const ButtonTransaction: React.FC<Props> = ({ txDetails, assetSelected }) => {
         type="button"
       >
         <div className="flex items-center">
-          <TxIcon txType={transfer?.type ?? TxType.Unknow} />
-          {blockHeader ? (
+          <TxIcon txType={txTypeFromTransfer(transferAmount())} />
+          {txDetails.blockHeader ? (
             <span className="text-grayDark items-center mr-2 text-xs font-medium text-left">
-              {moment(blockHeader.timestamp * 1000).format('DD MMM YYYY')}
+              {moment(txDetails.blockHeader.timestamp * 1000).format('DD MMM YYYY')}
             </span>
-          ) : isLoading ? (
-            <div role="status" className="animate-pulse w-full">
-              <div className="h-2.5 bg-primary rounded-full w-20"></div>
-            </div>
           ) : (
             <span className="bg-red inline-flex items-center justify-center px-2 py-1 text-xs font-semibold leading-none text-white rounded-full">
               unconfirmed
@@ -169,9 +66,9 @@ const ButtonTransaction: React.FC<Props> = ({ txDetails, assetSelected }) => {
         </div>
         <div className="flex">
           <div className="text-primary whitespace-nowrap text-sm font-medium">
-            {transfer ? (transfer.amount > 0 ? '+' : '') : ''}
-            {transfer
-              ? formatDecimalAmount(fromSatoshi(transfer.amount, assetSelected.precision))
+            {transferAmountIsDefined() ? (transferAmount() > 0 ? '+' : '') : ''}
+            {transferAmountIsDefined()
+              ? formatDecimalAmount(fromSatoshi(transferAmount(), assetSelected.precision))
               : '??'}{' '}
             {assetSelected.ticker}
           </div>
@@ -189,10 +86,10 @@ const ButtonTransaction: React.FC<Props> = ({ txDetails, assetSelected }) => {
             assetHash={assetSelected.assetHash}
             className="w-8 h-8 mt-0.5 block mx-auto mb-2"
           />
-          <p className="text-base font-medium">{transfer?.type}</p>
-          {blockHeader && (
+          <p className="text-base font-medium">{txTypeFromTransfer(transferAmount())}</p>
+          {txDetails.blockHeader && (
             <p className="text-xs font-light">
-              {moment(blockHeader.timestamp * 1000).format('DD MMMM YYYY HH:mm')}
+              {moment(txDetails.blockHeader.timestamp * 1000).format('DD MMMM YYYY HH:mm')}
             </p>
           )}
         </div>
@@ -209,22 +106,22 @@ const ButtonTransaction: React.FC<Props> = ({ txDetails, assetSelected }) => {
               </span>
             )}
           </div>
-          {transfer && (
+          {transferAmountIsDefined() && (
             <div>
-              <p className="text-sm font-medium">{transfer.amount > 0 ? 'Inbound' : 'Outbound'}</p>
+              <p className="text-sm font-medium">{transferAmount() > 0 ? 'Inbound' : 'Outbound'}</p>
               <p className="text-sm font-light">
-                {fromSatoshiStr(transfer.amount, assetSelected.precision)}{' '}
+                {fromSatoshiStr(transferAmount(), assetSelected.precision)}{' '}
                 {assetSelected.ticker ?? assetSelected.assetHash.slice(0, 4)}
               </p>
             </div>
           )}
           <div>
             <p className="text-base font-medium">Fee</p>
-            <p className="text-xs font-light">{fromSatoshiStr(feeAmount || 0)} L-BTC</p>
+            <p className="text-xs font-light">{fromSatoshiStr(txDetails.feeAmount || 0)} L-BTC</p>
           </div>
           <div>
             <p className="text-base font-medium">ID transaction</p>
-            <p className="wrap text-xs font-light break-all">{txID}</p>
+            <p className="wrap text-xs font-light break-all">{txDetails.txID}</p>
           </div>
         </div>
         <Button className="w-full" onClick={() => handleOpenExplorer()}>

--- a/src/extension/components/modal-menu.tsx
+++ b/src/extension/components/modal-menu.tsx
@@ -3,6 +3,7 @@ import { useHistory } from 'react-router';
 import { logOutMessage } from '../../domain/message';
 import useOnClickOutside from '../hooks/use-onclick-outside';
 import {
+  DEFAULT_ROUTE,
   SETTINGS_MENU_INFO_ROUTE,
   SETTINGS_MENU_SECURITY_ROUTE,
   SETTINGS_MENU_SETTINGS_ROUTE,
@@ -28,6 +29,7 @@ const ModalMenu: React.FC<Props> = ({ isOpen, handleClose }) => {
   const handleLogOut = async () => {
     await appRepository.updateStatus({ isAuthenticated: false });
     await backgroundPort.sendMessage(logOutMessage());
+    history.push(DEFAULT_ROUTE);
   };
 
   if (!isOpen) {

--- a/src/extension/wallet/home/index.tsx
+++ b/src/extension/wallet/home/index.tsx
@@ -58,7 +58,7 @@ const Home: React.FC = () => {
           break;
       }
     })().catch(console.error);
-  }, []);
+  }, [cache?.authenticated]);
 
   return (
     <ShellPopUp
@@ -88,6 +88,11 @@ const Home: React.FC = () => {
         <div className="h-60">
           <ButtonList title="Assets" emptyText="Click receive to deposit asset...">
             {cache?.assets
+              .filter(
+                (asset: Asset) =>
+                  cache?.transactions.find((tx) => tx.txFlow[asset.assetHash] !== undefined) !==
+                  undefined
+              )
               // put the assets with balance defined on top
               .sort((a, b) => {
                 const aBalance = cache?.balances[a.assetHash];

--- a/src/extension/wallet/transactions/index.tsx
+++ b/src/extension/wallet/transactions/index.tsx
@@ -14,7 +14,6 @@ import ButtonTransaction from '../../components/button-transaction';
 import ShellPopUp from '../../components/shell-popup';
 import { fromSatoshiStr } from '../../utility';
 import SaveMnemonicModal from '../../components/modal-save-mnemonic';
-import { useSelectTransactions } from '../../../infrastructure/storage/common';
 import type { Asset } from 'marina-provider';
 import { useStorageContext } from '../../context/storage-context';
 
@@ -23,14 +22,12 @@ interface LocationState {
 }
 
 const Transactions: React.FC = () => {
-  const { assetRepository, appRepository, sendFlowRepository, walletRepository, cache } =
-    useStorageContext();
+  const { assetRepository, appRepository, sendFlowRepository, cache } = useStorageContext();
 
   const {
     state: { assetHash },
   } = useLocation<LocationState>();
   const history = useHistory();
-  const transactions = useSelectTransactions(appRepository, walletRepository)();
   const [asset, setAsset] = useState<Asset>();
 
   useEffect(() => {
@@ -87,9 +84,11 @@ const Transactions: React.FC = () => {
           <div className="h-60 rounded-xl mb-1">
             {asset && (
               <ButtonList title="Transactions" emptyText="Your transactions will appear here">
-                {transactions.map((tx, index) => {
-                  return <ButtonTransaction txDetails={tx} assetSelected={asset} key={index} />;
-                })}
+                {cache?.transactions
+                  .filter((tx) => tx.txFlow[asset.assetHash] !== undefined)
+                  .map((tx, index) => {
+                    return <ButtonTransaction txDetails={tx} assetSelected={asset} key={index} />;
+                  })}
               </ButtonList>
             )}
           </div>

--- a/src/infrastructure/storage/common.ts
+++ b/src/infrastructure/storage/common.ts
@@ -1,19 +1,16 @@
 import type { Asset } from 'marina-provider';
 import { useEffect, useState } from 'react';
 import Browser from 'webextension-polyfill';
-import type { TxDetails } from '../../domain/transaction';
 import type { Encrypted } from '../../domain/encryption';
 import type {
-  AppRepository,
   CreateAccountParameters,
   SpendParameters,
   TaxiRepository,
-  WalletRepository,
 } from '../../domain/repository';
 import { OnboardingStorageKeys } from './onboarding-repository';
 import { PopupsStorageKeys } from './popups-repository';
 import { TaxiAssetsKey } from './taxi-repository';
-import { TxDetailsKey, WalletStorageKey } from './wallet-repository';
+import { WalletStorageKey } from './wallet-repository';
 
 export type MaybeNull<T> = Promise<T | null>;
 
@@ -101,61 +98,3 @@ export const useSelectTaxiAssets = (taxiRepository: TaxiRepository) => () => {
 
   return assets;
 };
-
-export const useSelectTransactions =
-  (appRepository: AppRepository, walletRepository: WalletRepository) => () => {
-    const [transactions, setTransactions] = useState<TxDetails[]>([]);
-
-    const updateTransactions = async () => {
-      const net = await appRepository.getNetwork();
-      if (!net) return;
-      const txIds = await walletRepository.getTransactions(net);
-      const details = await walletRepository.getTxDetails(...txIds);
-      const txDetails = Object.values(details).sort(sortTxDetails());
-
-      setTransactions(txDetails);
-
-      // check if we have the hex, if not fetch it
-      const chainSource = await appRepository.getChainSource();
-      if (chainSource) {
-        const txIDs = Object.entries(details)
-          .filter(([, details]) => !details.hex)
-          .map(([txID]) => txID);
-
-        console.debug(`Fetching ${txIDs.length} transactions from the chain source`);
-        const txs = await chainSource.fetchTransactions(txIDs);
-        await walletRepository.updateTxDetails(Object.fromEntries(txs.map((tx) => [tx.txID, tx])));
-      }
-    };
-
-    useEffect(() => {
-      const listener = async (changes: Browser.Storage.StorageChange, areaName: string) => {
-        if (areaName !== 'local') return;
-        for (const [key, change] of Object.entries(changes)) {
-          if (TxDetailsKey.is(key) && change.newValue) {
-            await updateTransactions();
-          }
-        }
-      };
-
-      updateTransactions().catch(console.error);
-
-      Browser.storage.onChanged.addListener(listener);
-      return () => {
-        Browser.storage.onChanged.removeListener(listener);
-      };
-    }, []);
-
-    return transactions;
-  };
-
-// sort function for txDetails, use the height member to sort
-// put unconfirmed txs first and then sort by height (desc)
-function sortTxDetails(): ((a: TxDetails, b: TxDetails) => number) | undefined {
-  return (a, b) => {
-    if (a.height === b.height) return 0;
-    if (!a.height || a.height === -1) return -1;
-    if (!b.height || b.height === -1) return 1;
-    return b.height - a.height;
-  };
-}

--- a/src/infrastructure/storage/wallet-repository.ts
+++ b/src/infrastructure/storage/wallet-repository.ts
@@ -451,29 +451,6 @@ export class WalletStorageAPI implements WalletRepository {
     return () => Browser.storage.onChanged.removeListener(listener);
   }
 
-  onUnblinding(callback: (outpoint: Outpoint, data: UnblindingData) => Promise<void>) {
-    const listener = async (
-      changes: Record<string, Browser.Storage.StorageChange>,
-      areaName: string
-    ) => {
-      if (areaName !== 'local') return;
-      const unblindingKeys = Object.entries(changes)
-        .filter(
-          ([key, changes]) => OutpointBlindingDataKey.is(key) && changes.newValue !== undefined
-        )
-        .map(([key]) => key);
-
-      for (const unblindingKey of unblindingKeys) {
-        const [txID, vout] = OutpointBlindingDataKey.decode(unblindingKey);
-        const data = changes[unblindingKey].newValue as UnblindingData;
-        await callback({ txID, vout }, data);
-      }
-    };
-
-    Browser.storage.onChanged.addListener(listener);
-    return () => Browser.storage.onChanged.removeListener(listener);
-  }
-
   async getAccountScripts(
     network: NetworkString,
     ...names: string[]


### PR DESCRIPTION
This PR drops the `useSelectTransactions` hook used in `transactions` view and compute the transactions list from repositories inside the `StorageContext` component. It lets to:
* speed up the transactions list rendering
* speed up the "transfer amount" computing
* be consistent with utxos list (also computed in StorageContext)

the PR also use that newly cached transactions list to filter the asset in `Home` view. it closes #437 

@tiero @bordalix please review this