### PR TITLE
Added precision to amount formatting in spend.tsx.

### DIFF
--- a/src/application/utils.ts
+++ b/src/application/utils.ts
@@ -8,7 +8,7 @@ export async function fetchAsset(webExplorerURL: string, asset: string) {
   return {
     name: name || 'Unknown',
     ticker: ticker || asset.substring(0, 4),
-    precision: precision || 8,
+    precision: precision ?? 8,
     assetHash: asset,
   };
 }

--- a/src/extension/popups/spend.tsx
+++ b/src/extension/popups/spend.tsx
@@ -36,6 +36,11 @@ const ConnectSpend: React.FC = () => {
     return assetInfo ? assetInfo.ticker : asset.slice(0, 4);
   };
 
+  const getPrecision = (asset: string) => {
+    const assetInfo = cache?.assets.find((a) => a.assetHash === asset);
+    return assetInfo ? assetInfo.precision : 8;
+  };
+
   const handleModalUnlockClose = () => showUnlockModal(false);
   const handleUnlockModalOpen = () => showUnlockModal(true);
 
@@ -103,7 +108,9 @@ const ConnectSpend: React.FC = () => {
             {spendParameters.addressRecipients.map((recipient, index) => (
               <div key={index}>
                 <div className="container flex justify-between mt-6">
-                  <span className="text-lg font-medium">{fromSatoshi(recipient.value)}</span>
+                  <span className="text-lg font-medium">
+                    {(fromSatoshi(recipient.value), getPrecision(recipient.asset))}
+                  </span>
                   <span className="text-lg font-medium">{getTicker(recipient.asset)}</span>
                 </div>
                 <div className="container flex items-baseline justify-between">


### PR DESCRIPTION
I also included a change in utils.ts's `fetchAsset` to explicitly check whether the precision is null or undefined before assigning the default value of 8 because the valid precision value of 0 always falls into the falsy case and can never be set.

Closes #449 