### PR TITLE
`settings/networks` sends restoreMessage to background

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "liquidjs-lib": "^6.0.2-liquid.23",
     "lodash.debounce": "^4.0.8",
     "lottie-web": "^5.7.8",
-    "marina-provider": "https://github.com/louisinger/marina-provider.git#new-provider",
+    "marina-provider": "^2.0.0",
     "moment": "^2.29.4",
     "path-browserify": "^1.0.1",
     "postcss": "^7.0.35",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5609,9 +5609,10 @@ map-age-cleaner@^0.1.3:
   dependencies:
     p-defer "^1.0.0"
 
-"marina-provider@https://github.com/louisinger/marina-provider.git#new-provider":
-  version "1.7.2"
-  resolved "https://github.com/louisinger/marina-provider.git#db29a8a760811f1431243b5572f04eb72786b400"
+marina-provider@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/marina-provider/-/marina-provider-2.0.0.tgz#f684998e2c64be88c8f4674d2ae4d9887ce566d0"
+  integrity sha512-C/TToZV5tYXsGeUe8ux6+gE+g+ihcdXfxj1VoDo3S4fhdvjwMKvNLzUEmpZJHyJ/rMcbGUHVagKR1MPsueE3Ig==
 
 marky@^1.2.2:
   version "1.2.5"


### PR DESCRIPTION
This PR removes the `sync` calls made in UI and send "restore" messages to background. In other words, the restoration after a network change is made in background.

Bonus: `pkg.json` now fetch `marina-provider` from NPM.
 
it closes #447 

@bordalix @tiero please review

