### PR TITLE
start background services before restore step in `onboarding/end-of-flow` 

### DIFF
--- a/src/domain/message.ts
+++ b/src/domain/message.ts
@@ -56,8 +56,8 @@ export interface Message<T> {
 
 export type PopupResponseMessage<ResponseT> = Message<{ response?: ResponseT; error?: string }>;
 export type OpenPopupMessage = Message<{ name: PopupName }>;
-export type LogInMessage = Message<undefined>;
-export type LogOutMessage = Message<undefined>;
+export type StartServicesMessage = Message<undefined>;
+export type StopServicesMessage = Message<undefined>;
 export type RestoreMessage = Message<{
   accountID: AccountID;
   network: NetworkString;
@@ -93,19 +93,19 @@ export function isPopupResponseMessage(message: unknown): message is PopupRespon
   return message && (message as any).type === MessageType.PopupResponse && (message as any).data;
 }
 
-export function logInMessage(): LogInMessage {
+export function startServicesMessage(): StartServicesMessage {
   return { type: MessageType.Login, data: undefined };
 }
 
-export function isLogInMessage(message: unknown): message is LogInMessage {
+export function isStartServicesMessage(message: unknown): message is StartServicesMessage {
   return (message && (message as any).type === MessageType.Login) as boolean;
 }
 
-export function logOutMessage(): LogOutMessage {
+export function stopServicesMessage(): StopServicesMessage {
   return { type: MessageType.Logout, data: undefined };
 }
 
-export function isLogOutMessage(message: unknown): message is LogOutMessage {
+export function isStopSevicesMessage(message: unknown): message is StopServicesMessage {
   return (message && (message as any).type === MessageType.Logout) as boolean;
 }
 

--- a/src/extension/components/modal-menu.tsx
+++ b/src/extension/components/modal-menu.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef } from 'react';
 import { useHistory } from 'react-router';
-import { logOutMessage } from '../../domain/message';
+import { stopServicesMessage } from '../../domain/message';
 import useOnClickOutside from '../hooks/use-onclick-outside';
 import {
   DEFAULT_ROUTE,
@@ -28,7 +28,7 @@ const ModalMenu: React.FC<Props> = ({ isOpen, handleClose }) => {
   const handleInfo = () => history.push(SETTINGS_MENU_INFO_ROUTE);
   const handleLogOut = async () => {
     await appRepository.updateStatus({ isAuthenticated: false });
-    await backgroundPort.sendMessage(logOutMessage());
+    await backgroundPort.sendMessage(stopServicesMessage());
     history.push(DEFAULT_ROUTE);
   };
 

--- a/src/extension/onboarding/end-of-flow/index.tsx
+++ b/src/extension/onboarding/end-of-flow/index.tsx
@@ -19,11 +19,14 @@ import { mnemonicToSeed } from 'bip39';
 import { initWalletRepository } from '../../../domain/repository';
 import type { ChainSource } from '../../../domain/chainsource';
 import { useStorageContext } from '../../context/storage-context';
+import { useBackgroundPortContext } from '../../context/background-port-context';
+import { startServicesMessage } from '../../../domain/message';
 
 const GAP_LIMIT = 30;
 
 const EndOfFlowOnboarding: React.FC = () => {
   const { appRepository, onboardingRepository, walletRepository } = useStorageContext();
+  const { backgroundPort } = useBackgroundPortContext();
   const isFromPopup = useSelectIsFromPopupFlow();
 
   const [isLoading, setIsLoading] = useState(true);
@@ -46,6 +49,8 @@ const EndOfFlowOnboarding: React.FC = () => {
       setIsLoading(true);
       setErrorMsg(undefined);
       checkPassword(onboardingPassword);
+      // start services in background
+      await backgroundPort.sendMessage(startServicesMessage());
 
       const { masterBlindingKey, defaultMainAccountXPub, defaultLegacyMainAccountXPub } =
         await initWalletRepository(walletRepository, onboardingMnemonic, onboardingPassword);

--- a/src/extension/wallet/log-in/index.tsx
+++ b/src/extension/wallet/log-in/index.tsx
@@ -9,7 +9,7 @@ import Input from '../../components/input';
 import { INVALID_PASSWORD_ERROR } from '../../../domain/constants';
 import { useSelectEncryptedMnemonic } from '../../../infrastructure/storage/common';
 import Browser from 'webextension-polyfill';
-import { logInMessage } from '../../../domain/message';
+import { startServicesMessage } from '../../../domain/message';
 import type { Encrypted } from '../../../domain/encryption';
 import { decrypt } from '../../../domain/encryption';
 import { useStorageContext } from '../../context/storage-context';
@@ -92,7 +92,7 @@ const LogIn: React.FC = () => {
 
   const onSuccess = async () => {
     await appRepository.updateStatus({ isAuthenticated: true });
-    await backgroundPort.sendMessage(logInMessage());
+    await backgroundPort.sendMessage(startServicesMessage());
     history.push(DEFAULT_ROUTE);
   };
 


### PR DESCRIPTION
This PR ensures that the onboarding/end-of-flow restoration page starts the background services before doing the restoration process (in order to trigger the fetch/unblind tx process).

@tiero please review
