### PR TITLE
Fix manifest v2 extension & release v2 artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,10 +38,14 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Bundle app
-        run: yarn run build
+        run: |
+          yarn run build
+          yarn run build:v3
 
       - name: Package the extension
-        run: yarn run web-ext:build
+        run: |
+          yarn run web-ext:build
+          yarn run web-ext:build:v3
 
       - name: Lint
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-      - "v*"
+      - 'v*'
 
 name: Release
 
@@ -20,7 +20,7 @@ jobs:
       # setup nodejs
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: '16'
 
       # get current  tag
       - name: tag
@@ -43,30 +43,59 @@ jobs:
           jq '.version = "${{ steps.next_version.outputs.version }}"' package.json  > package.tmp.json
           mv package.tmp.json package.json
 
-      # Build extension
-      - name: Install and build
+      - name: Install the dependencies
+        run: yarn install
+
+      # Build extension v3
+      - name: Build extension manifest v3
         run: |
-          yarn install
           yarn build:v3
-          yarn web-ext:build
+          yarn web-ext:build:v3
 
       # Release to github
-      - name: Create Release
+      - name: Create Release (manifest v3)
         id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-      - name: Upload release
+          release_name: Release ${{ github.ref }} (manifest v3)
+
+      - name: Upload release (manifest v3)
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./web-ext-artifacts/marina-${{ steps.next_version.outputs.version }}.zip
-          asset_name: marina-${{ steps.next_version.outputs.version }}.zip
+          asset_path: ./web-ext-artifacts/v3/marina-${{ steps.next_version.outputs.version }}.zip
+          asset_name: marina-v3-${{ steps.next_version.outputs.version }}.zip
+          asset_content_type: application/zip
+
+      # Build extension v2
+      - name: Build extension manifest v2
+        run: |
+          yarn build:v2
+          yarn web-ext:build:v2
+
+      # Release to github
+      - name: Create Release (manifest v2)
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }} (manifest v2)
+
+      - name: Upload release (manifest v2)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./web-ext-artifacts/v2/marina-${{ steps.next_version.outputs.version }}.zip
+          asset_name: marina-v2-${{ steps.next_version.outputs.version }}.zip
           asset_content_type: application/zip
 
       # Comit manifest and package.json to master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,8 +75,8 @@ jobs:
       # Build extension v2
       - name: Build extension manifest v2
         run: |
-          yarn build:v2
-          yarn web-ext:build:v2
+          yarn build
+          yarn web-ext:build
 
       # Release to github
       - name: Create Release (manifest v2)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,15 +52,21 @@ jobs:
           yarn build:v3
           yarn web-ext:build:v3
 
+      # Build extension v2
+      - name: Build extension manifest v2
+        run: |
+          yarn build
+          yarn web-ext:build
+
       # Release to github
-      - name: Create Release (manifest v3)
+      - name: Create Release
         id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }} (manifest v3)
+          release_name: Release ${{ github.ref }}
 
       - name: Upload release (manifest v3)
         uses: actions/upload-release-asset@v1
@@ -71,22 +77,6 @@ jobs:
           asset_path: ./web-ext-artifacts/v3/marina-${{ steps.next_version.outputs.version }}.zip
           asset_name: marina-v3-${{ steps.next_version.outputs.version }}.zip
           asset_content_type: application/zip
-
-      # Build extension v2
-      - name: Build extension manifest v2
-        run: |
-          yarn build
-          yarn web-ext:build
-
-      # Release to github
-      - name: Create Release (manifest v2)
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }} (manifest v2)
 
       - name: Upload release (manifest v2)
         uses: actions/upload-release-asset@v1

--- a/manifest/manifest.v2.json
+++ b/manifest/manifest.v2.json
@@ -39,7 +39,7 @@
   "web_accessible_resources": [
     "inject-script.js"
   ],
-  "content_security_policy": "script-src 'self' 'wasm-eval'; object-src 'self'",
+  "content_security_policy": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'",
   "browser_action": {
     "default_icon": {
       "16": "assets/images/logo/marina_logo_16x16.png",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:playwright": "playwright test",
     "prettier": "prettier --write src test",
     "prettier:check": "prettier --check src test",
-    "web-ext:build": "web-ext build --source-dir dist --overwrite-dest",
+    "web-ext:build": "web-ext build --source-dir dist/v2 --overwrite-dest --artifacts-dir web-ext-artifacts/v2/",
+    "web-ext:build:v3": "web-ext build --source-dir dist/v3 --overwrite-dest --artifacts-dir web-ext-artifacts/v3/",
     "web-ext:lint": "web-ext lint --source-dir dist"
   },
   "dependencies": {

--- a/playwright-tests/utils.ts
+++ b/playwright-tests/utils.ts
@@ -9,7 +9,7 @@ export const test = basePlaywrightTest.extend<{
 }>({
     // eslint-disable-next-line no-empty-pattern
     context: async ({ }, use) => {
-        const pathToExtension = path.join(__dirname, '../dist');
+        const pathToExtension = path.join(__dirname, '../dist', 'v3');
         const context = await chromium.launchPersistentContext('', {
             headless: false,
             args: [

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -50,5 +50,5 @@ module.exports = (env) => ({
       'process.env.MANIFEST_VERSION': JSON.stringify(env.version),
     })
   ],
-  output: { filename: '[name].js', path: path.resolve(__dirname, 'dist') },
+  output: { filename: '[name].js', path: path.resolve(__dirname, 'dist', env.version) },
 });


### PR DESCRIPTION
### This PR fixes v2 version of the extension & adds a release artifact.

- `dist` & `web-ext-artifacts` folders are now divided into `v2` & `v3` directories, depending on which version of the extension you are building.
- add a `web-ext:build:v3` script in pkg.json
- `main.yml` CI is now testing v2 AND v3 build & bundle.
- `release.yml` now upload two artifacts: `marina-v3-{version}.zip` & `marina-v2-{version}.zip`.

_Unfortunately it's not possible to run the playwright tests under Firefox cause playwright supports extension context only on Chrome-based browsers._

please @tiero review this