### PR TITLE
nit: message when activating wallet

### DIFF
--- a/src/extension/onboarding/end-of-flow/index.tsx
+++ b/src/extension/onboarding/end-of-flow/index.tsx
@@ -191,7 +191,8 @@ const EndOfFlowOnboarding: React.FC = () => {
     return (
       <div className="flex flex-col items-center justify-center h-screen p-24">
         <MermaidLoader className="h-1/2 flex items-center justify-center" />
-        <p>We are restoring your wallet. This can take a while, please do not close this window.</p>
+        <p>We are activating your wallet.</p>
+        <p>This can take a while, please do not close this window.</p>
         {numberOfTransactionsToRestore > 0 && (
           <div className="flex flex-col items-center justify-center mt-4">
             <Spinner />


### PR DESCRIPTION
The same message is shown when the user is restoring or creating a new wallet, so the wording "activating" seems more reasonable than "restoring".

Also, breaks the text message into 2 lines for legibility.

Before:

![Screenshot 2023-04-12 at 15 19 11](https://user-images.githubusercontent.com/9318412/231487283-030aa1ab-8fbc-473f-8358-4c22e449c672.png)

After:

![Screenshot 2023-04-12 at 15 16 31](https://user-images.githubusercontent.com/9318412/231487360-b4ed7578-c23e-452d-9e21-9aba455dfa17.png)

@tiero please review