### PR TITLE
Show data about pset to sign inside `marina.signTransaction` popup

### DIFF
--- a/playwright-tests/injected-script.spec.ts
+++ b/playwright-tests/injected-script.spec.ts
@@ -1,25 +1,109 @@
-import type { MarinaProvider } from 'marina-provider';
-import Marina from '../src/inject/marina/provider';
-import { test as pwTest, expect as pwExpect, makeOnboardingRestore } from './utils';
+import { Creator, Transaction, Updater, address, networks } from 'liquidjs-lib';
+import {
+  test as pwTest,
+  expect as pwExpect,
+  makeOnboardingRestore,
+  PlaywrightMarinaProvider,
+  marinaURL,
+  PASSWORD,
+} from './utils';
+import { faucet } from '../test/_regtest';
 
 const vulpemFaucetURL = 'https://faucet.vulpem.com/';
 
 pwTest('should set up a window.marina object', async ({ page }) => {
-    await page.goto(vulpemFaucetURL);
-    // test if the window.marina object is set up
-    // use isEnabled() to check if the functions are available
-    const isEnableViaProvider = await page.evaluate(
-      (name: string) => (window[name as any] as unknown as MarinaProvider).isEnabled(), 
-      Marina.PROVIDER_NAME
-    );
-    pwExpect(isEnableViaProvider).toBe(false);
+  await page.goto(vulpemFaucetURL);
+  // test if the window.marina object is set up
+  // use isEnabled() to check if the functions are available
+  const isEnableViaProvider = await new PlaywrightMarinaProvider(page).isEnabled();
+  pwExpect(isEnableViaProvider).toBe(false);
 });
 
-pwTest('should be able to connect to a web app (faucet.vulpem.com)', async ({ page, extensionId, context }) => {
-  await makeOnboardingRestore(page, extensionId);
-  await page.goto(vulpemFaucetURL);
-  await page.getByRole('button', { name: 'Connect with Marina' }).click();
-  const popup = await context.waitForEvent('page');
-  await popup.getByRole('button', { name: 'Connect' }).click();
-  pwExpect(page.getByText('Wrong network, switch to the Testnet')).toBeTruthy();
-});
+pwTest(
+  'should be able to connect to a web app (faucet.vulpem.com)',
+  async ({ page, extensionId, context }) => {
+    await makeOnboardingRestore(page, extensionId);
+    await page.goto(vulpemFaucetURL);
+    await page.getByRole('button', { name: 'Connect with Marina' }).click();
+    const popup = await context.waitForEvent('page');
+    await popup.getByRole('button', { name: 'Connect' }).click();
+    pwExpect(page.getByText('Wrong network, switch to the Testnet')).toBeTruthy();
+    const provider = new PlaywrightMarinaProvider(page);
+    pwExpect(await provider.isEnabled()).toBe(true);
+  }
+);
+
+pwTest(
+  'marina.signTransaction popup should display the correct amount of spent asset',
+  async ({ page, extensionId, context }) => {
+    await makeOnboardingRestore(page, extensionId);
+    // login and switch to regtest network
+    await page.goto(marinaURL(extensionId, 'popup.html'));
+    await page.getByPlaceholder('Enter your password').fill(PASSWORD);
+    await page.getByRole('button', { name: 'Log in' }).click();
+    await page.waitForSelector('text=Assets');
+    await page.getByAltText('menu icon').click(); // hamburger menu
+    await page.getByText('Settings').click();
+    await page.getByRole('button', { name: 'Networks' }).click();
+    await page.getByRole('button', { name: 'Liquid' }).click(); // by default on Liquid, so the button contains the network name
+    await page.getByText('Regtest').click();
+
+    await page.goto(vulpemFaucetURL);
+    let provider = new PlaywrightMarinaProvider(page);
+    if (!(await provider.isEnabled())) {
+      await page.getByRole('button', { name: 'Connect with Marina' }).click();
+      const popup = await context.waitForEvent('page');
+      await popup.getByRole('button', { name: 'Connect' }).click();
+    }
+    const toFaucet = await provider.getNextAddress();
+    await faucet(toFaucet.confidentialAddress, 1); // send 1 L-BTC to the address
+    await page.goto(marinaURL(extensionId, 'popup.html'));
+    await page.waitForSelector('text=1 L-BTC');
+
+    await page.goto(vulpemFaucetURL);
+    provider = new PlaywrightMarinaProvider(page);
+    const [coin] = await provider.getCoins();
+    // random regtest address
+    const receiver = 'el1qqdfjtdv5a7jez0qmj5g4u07pcg0qsm8jrwx0c6rza8kmquad2k62mwxw92f7vw0460wdx36m97er86rlkl3xsz774h2w3zpc9'
+    
+    const pset = Creator.newPset();
+    const updater = new Updater(pset);
+    pwExpect(coin.blindingData).toBeTruthy();
+    pwExpect(coin.blindingData!.asset).toEqual(networks.regtest.assetHash);
+    pwExpect(coin.blindingData!.value).toEqual(1_0000_0000);
+    updater.addInputs([
+      {
+        txid: coin.txid,
+        txIndex: coin.vout,
+        witnessUtxo: coin.witnessUtxo,
+        sighashType: Transaction.SIGHASH_ALL,
+      },
+    ]);
+    updater.addOutputs([
+      {
+        amount: coin.blindingData!.value - 1500,
+        asset: networks.regtest.assetHash,
+        script: address.toOutputScript(receiver),
+        blinderIndex: 0,
+        blindingPublicKey: address.fromConfidential(receiver).blindingKey,
+      },
+      {
+        amount: 1500,
+        asset: networks.regtest.assetHash,
+      },
+    ]);
+
+    const psetBase64 = pset.toBase64();
+
+    const handleSignTransactionPopup = async () => {
+      const popup = await context.waitForEvent('page');
+      await popup.waitForSelector(`text=1 L-BTC`);
+      await popup.getByRole('button', { name: 'Accept' }).click();
+      // fill password
+      await popup.getByPlaceholder('Password').fill(PASSWORD);
+      await popup.getByRole('button', { name: 'Unlock' }).click();
+    };
+
+    await Promise.all([provider.signTransaction(psetBase64), handleSignTransactionPopup()]);
+  }
+);

--- a/playwright-tests/injected-script.spec.ts
+++ b/playwright-tests/injected-script.spec.ts
@@ -98,12 +98,12 @@ pwTest(
     const handleSignTransactionPopup = async () => {
       const popup = await context.waitForEvent('page');
       await popup.waitForSelector(`text=1 L-BTC`);
-      await popup.getByRole('button', { name: 'Accept' }).click();
-      // fill password
-      await popup.getByPlaceholder('Password').fill(PASSWORD);
-      await popup.getByRole('button', { name: 'Unlock' }).click();
+      await popup.getByRole('button', { name: 'Reject' }).click();
     };
 
-    await Promise.all([provider.signTransaction(psetBase64), handleSignTransactionPopup()]);
+    await Promise.all([
+      pwExpect(provider.signTransaction(psetBase64)).rejects.toThrow('User rejected the sign request'),
+      handleSignTransactionPopup(),
+    ]);
   }
 );

--- a/playwright-tests/utils.ts
+++ b/playwright-tests/utils.ts
@@ -1,43 +1,60 @@
 import type { BrowserContext, Page } from '@playwright/test';
 import { test as basePlaywrightTest, chromium } from '@playwright/test';
 import { generateMnemonic } from 'bip39';
+import type {
+  AccountInfo,
+  AccountType,
+  Address,
+  ArtifactWithConstructorArgs,
+  Balance,
+  MarinaEventType,
+  MarinaProvider,
+  NetworkString,
+  Recipient,
+  SentTransaction,
+  SignedMessage,
+  Transaction,
+  Utxo,
+} from 'marina-provider';
 import path from 'path';
+import Marina from '../src/inject/marina/provider';
 
 export const test = basePlaywrightTest.extend<{
-    context: BrowserContext;
-    extensionId: string;
+  context: BrowserContext;
+  extensionId: string;
 }>({
-    // eslint-disable-next-line no-empty-pattern
-    context: async ({ }, use) => {
-        const pathToExtension = path.join(__dirname, '../dist');
-        const context = await chromium.launchPersistentContext('', {
-            headless: false,
-            args: [
-                `--disable-extensions-except=${pathToExtension}`,
-                `--load-extension=${pathToExtension}`,
-            ],
-        });
-        await use(context);
-        await context.close();
-    },
-    extensionId: async ({ context }, use) => {
-        let extensionID = '';
-        if (process.env.MANIFEST_VERSION === 'v2') {
-            let [backgroundPage] = context.backgroundPages()
-            if (!backgroundPage) backgroundPage = await context.waitForEvent('backgroundpage')
-            extensionID = backgroundPage.url().split('/')[2]
-        } else {
-            let [serviceWorker] = context.serviceWorkers()
-            if (!serviceWorker) serviceWorker = await context.waitForEvent('serviceworker')
-            extensionID = serviceWorker.url().split('/')[2]
-        }
-        await use(extensionID);
-    },
+  // eslint-disable-next-line no-empty-pattern
+  context: async ({}, use) => {
+    const pathToExtension = path.join(__dirname, '../dist');
+    const context = await chromium.launchPersistentContext('', {
+      headless: false,
+      args: [
+        `--disable-extensions-except=${pathToExtension}`,
+        `--load-extension=${pathToExtension}`,
+      ],
+    });
+    await use(context);
+    await context.close();
+  },
+  extensionId: async ({ context }, use) => {
+    let extensionID = '';
+    if (process.env.MANIFEST_VERSION === 'v2') {
+      let [backgroundPage] = context.backgroundPages();
+      if (!backgroundPage) backgroundPage = await context.waitForEvent('backgroundpage');
+      extensionID = backgroundPage.url().split('/')[2];
+    } else {
+      let [serviceWorker] = context.serviceWorkers();
+      if (!serviceWorker) serviceWorker = await context.waitForEvent('serviceworker');
+      extensionID = serviceWorker.url().split('/')[2];
+    }
+    await use(extensionID);
+  },
 });
 
 export const PASSWORD = 'passwordsupersecretonlyfortesting';
 
-export const marinaURL = (extensionID: string, path: string) => `chrome-extension://${extensionID}/${path}`;
+export const marinaURL = (extensionID: string, path: string) =>
+  `chrome-extension://${extensionID}/${path}`;
 
 export const makeOnboardingRestore = async (page: Page, extensionID: string) => {
   await page.goto(marinaURL(extensionID, 'home.html#initialize/welcome'));
@@ -54,3 +71,129 @@ export const makeOnboardingRestore = async (page: Page, extensionID: string) => 
 };
 
 export const expect = test.expect;
+
+// detects { '0': x, '1': y, ... } shape of Uint8Array
+function isSpecialUint8Array(value: unknown): value is Record<string, number> {
+  return typeof value === 'object' &&
+    value !== null &&
+    Object.keys(value).every((k) => /^\d+$/.test(k)) &&
+    Object.values(value).every((v) => typeof v === 'number' && v >= 0 && v <= 255);
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+// we need this to handle special shape of Buffer in the Playwright 'evaluate' environment
+function bufferCast<T extends Record<string, any>>(obj: T): T {
+  // cast all { '0': x, '1': y, ... } to Buffer
+  return Object.fromEntries(
+    Object.entries(obj).map(([k, v]) => [
+      k,
+      isObject(v) ? (isSpecialUint8Array(v) ? Buffer.from(Object.values(v)) : bufferCast(v)) : v,
+    ])
+  ) as T;
+}
+
+// lets to call marina provider function in the current page
+// implements only the methods that are used in the tests
+export class PlaywrightMarinaProvider implements MarinaProvider {
+  constructor(private page: Page) {}
+
+  enable(): Promise<void> {
+    return this.page.evaluate(
+      (name: string) => (window[name as any] as unknown as MarinaProvider).enable(),
+      Marina.PROVIDER_NAME
+    );
+  }
+  disable(): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+  isEnabled(): Promise<boolean> {
+    return this.page.evaluate(
+      (name: string) => (window[name as any] as unknown as MarinaProvider).isEnabled(),
+      Marina.PROVIDER_NAME
+    );
+  }
+  isReady(): Promise<boolean> {
+    throw new Error('Method not implemented.');
+  }
+  on(type: MarinaEventType, callback: (payload: any) => void): string {
+    throw new Error('Method not implemented.');
+  }
+  off(listenerId: string): void {
+    throw new Error('Method not implemented.');
+  }
+  getNetwork(): Promise<NetworkString> {
+    throw new Error('Method not implemented.');
+  }
+  getFeeAssets(): Promise<string[]> {
+    throw new Error('Method not implemented.');
+  }
+  getSelectedAccount(): Promise<string> {
+    throw new Error('Method not implemented.');
+  }
+  getAccountsIDs(): Promise<string[]> {
+    throw new Error('Method not implemented.');
+  }
+  getAccountInfo(accountID: string): Promise<AccountInfo> {
+    throw new Error('Method not implemented.');
+  }
+  createAccount(accountID: string, accountType: AccountType): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+  getBalances(accountIDs?: string[] | undefined): Promise<Balance[]> {
+    throw new Error('Method not implemented.');
+  }
+  async getCoins(accountIDs?: string[] | undefined): Promise<Utxo[]> {
+    const coins = await this.page.evaluate<Utxo[], string[]>(
+      ([name, ...accountIDs]) =>
+        (window[name as any] as unknown as MarinaProvider).getCoins(accountIDs),
+      [Marina.PROVIDER_NAME, ...(accountIDs || [])]
+    );
+    return coins.map(bufferCast);
+  }
+  getTransactions(accountIDs?: string[] | undefined): Promise<Transaction[]> {
+    throw new Error('Method not implemented.');
+  }
+  getAddresses(accountIDs?: string[] | undefined): Promise<Address[]> {
+    throw new Error('Method not implemented.');
+  }
+  sendTransaction(
+    recipients: Recipient[],
+    feeAsset?: string | undefined
+  ): Promise<SentTransaction> {
+    throw new Error('Method not implemented.');
+  }
+  signTransaction(pset: string): Promise<string> {
+    return this.page.evaluate<string, [string, string]>(
+      ([name, pset]) => (window[name as any] as unknown as MarinaProvider).signTransaction(pset),
+      [Marina.PROVIDER_NAME, pset]
+    );
+  }
+  broadcastTransaction(signedTxHex: string): Promise<SentTransaction> {
+    throw new Error('Method not implemented.');
+  }
+  blindTransaction(pset: string): Promise<string> {
+    return this.page.evaluate<string, [string, string]>(
+      ([name, pset]) => (window[name as any] as unknown as MarinaProvider).blindTransaction(pset),
+      [Marina.PROVIDER_NAME, pset]
+    );
+  }
+  useAccount(accountID: string): Promise<boolean> {
+    throw new Error('Method not implemented.');
+  }
+  getNextAddress(ionioArtifact?: ArtifactWithConstructorArgs | undefined): Promise<Address> {
+    return this.page.evaluate<Address, [string, ArtifactWithConstructorArgs | undefined]>(
+      ([name, ionioArtifact]) =>
+        (window[name as any] as unknown as MarinaProvider).getNextAddress(ionioArtifact),
+      [Marina.PROVIDER_NAME, ionioArtifact]
+    );
+  }
+  getNextChangeAddress(ionioArtifact?: ArtifactWithConstructorArgs | undefined): Promise<Address> {
+    throw new Error('Method not implemented.');
+  }
+  signMessage(message: string): Promise<SignedMessage> {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/src/application/blinder.ts
+++ b/src/application/blinder.ts
@@ -16,7 +16,7 @@ export class BlinderService {
     const ownedInputs: OwnedInput[] = [];
     const inputsBlindingData = await this.walletRepository.getOutputBlindingData(
       ...pset.inputs.map(({ previousTxIndex, previousTxid }) => ({
-        txID: Buffer.from(previousTxid).reverse().toString('hex'),
+        txid: Buffer.from(previousTxid).reverse().toString('hex'),
         vout: previousTxIndex,
       }))
     );

--- a/src/application/presenter.ts
+++ b/src/application/presenter.ts
@@ -176,24 +176,24 @@ export class PresenterImpl implements Presenter {
       ...['liquid', 'testnet', 'regtest']
         .map((network) => [
           this.walletRepository.onNewUtxo(network as NetworkString)(
-            async ({ txID, vout, blindingData }) => {
+            async ({ txid, vout, blindingData }) => {
               if (!this.state.authenticated.value) return;
               if (network !== this.state.network) return;
               this.state = {
                 ...this.state,
-                utxos: setValue([...this.state.utxos.value, { txID, vout, blindingData }]),
+                utxos: setValue([...this.state.utxos.value, { txid, vout, blindingData }]),
               };
               this.state = await this.updateBalances();
               emits(this.state);
             }
           ),
-          this.walletRepository.onDeleteUtxo(network as NetworkString)(async ({ txID, vout }) => {
+          this.walletRepository.onDeleteUtxo(network as NetworkString)(async ({ txid, vout }) => {
             if (!this.state.authenticated.value) return;
             if (network !== this.state.network) return;
             this.state = {
               ...this.state,
               utxos: setValue(
-                this.state.utxos.value.filter((utxo) => utxo.txID !== txID || utxo.vout !== vout)
+                this.state.utxos.value.filter((utxo) => utxo.txid !== txid || utxo.vout !== vout)
               ),
             };
             this.state = await this.updateBalances();
@@ -204,14 +204,14 @@ export class PresenterImpl implements Presenter {
     );
 
     closeFns.push(
-      this.walletRepository.onUnblindingEvent(async ({ txID, vout, blindingData }) => {
+      this.walletRepository.onUnblindingEvent(async ({ txid, vout, blindingData }) => {
         if (!this.state.authenticated.value) return;
-        if (this.state.utxos.value.find((utxo) => utxo.txID === txID && utxo.vout === vout)) {
+        if (this.state.utxos.value.find((utxo) => utxo.txid === txid && utxo.vout === vout)) {
           this.state = {
             ...this.state,
             utxos: setValue(
               this.state.utxos.value.map((utxo) =>
-                utxo.txID === txID && utxo.vout === vout ? { txID, vout, blindingData } : utxo
+                utxo.txid === txid && utxo.vout === vout ? { txid, vout, blindingData } : utxo
               )
             ),
           };

--- a/src/application/unblinder.ts
+++ b/src/application/unblinder.ts
@@ -4,7 +4,12 @@ import type { ZKPInterface } from 'liquidjs-lib/src/confidential';
 import { confidentialValueToSatoshi } from 'liquidjs-lib/src/confidential';
 import type { Output, Transaction } from 'liquidjs-lib/src/transaction';
 import { SLIP77Factory } from 'slip77';
-import type { AppRepository, AssetRepository, Outpoint, WalletRepository } from '../domain/repository';
+import type {
+  AppRepository,
+  AssetRepository,
+  Outpoint,
+  WalletRepository,
+} from '../domain/repository';
 import { DefaultAssetRegistry } from '../port/asset-registry';
 import type { UnblindingData } from 'marina-provider';
 
@@ -87,9 +92,7 @@ export class WalletRepositoryUnblinder implements Unblinder {
     return unblindingResults;
   }
 
-  async unblindTxs(
-    ...txs: Transaction[]
-  ): Promise<[Outpoint, UnblindingData][]> {
+  async unblindTxs(...txs: Transaction[]): Promise<[Outpoint, UnblindingData][]> {
     const unblindedOutpoints: Array<[Outpoint, UnblindingData]> = [];
 
     for (const tx of txs) {

--- a/src/content/marina/marinaBroker.ts
+++ b/src/content/marina/marinaBroker.ts
@@ -168,7 +168,7 @@ export default class MarinaBroker extends Broker<keyof Marina> {
           unspent.blindingData = unblinded;
           try {
             await this.walletRepository.updateOutpointBlindingData([
-              [{ txID: unspent.txid, vout: unspent.vout }, unblinded],
+              [{ txid: unspent.txid, vout: unspent.vout }, unblinded],
             ]);
           } catch (e) {
             console.error(e);

--- a/src/content/marina/marinaBroker.ts
+++ b/src/content/marina/marinaBroker.ts
@@ -13,7 +13,7 @@ import { WalletStorageAPI } from '../../infrastructure/storage/wallet-repository
 import { AppStorageAPI } from '../../infrastructure/storage/app-repository';
 import type { SignTransactionPopupResponse } from '../../extension/popups/sign-pset';
 import type { SignMessagePopupResponse } from '../../extension/popups/sign-msg';
-import type { TxDetails, UnblindedOutput } from '../../domain/transaction';
+import type { TxDetails } from '../../domain/transaction';
 import { lockTransactionInputs, computeBalances } from '../../domain/transaction';
 import { AssetStorageAPI } from '../../infrastructure/storage/asset-repository';
 import { TaxiStorageAPI } from '../../infrastructure/storage/taxi-repository';
@@ -45,6 +45,7 @@ import type {
   NetworkString,
   Recipient,
   ScriptDetails,
+  UnblindedOutput,
   Utxo,
 } from 'marina-provider';
 import { AccountType, isAddressRecipient, isDataRecipient } from 'marina-provider';
@@ -96,7 +97,7 @@ export default class MarinaBroker extends Broker<keyof Marina> {
   }
 
   private async unblindedOutputToUtxo(coin: UnblindedOutput): Promise<Utxo> {
-    const witnessUtxo = await this.walletRepository.getWitnessUtxo(coin.txID, coin.vout);
+    const witnessUtxo = await this.walletRepository.getWitnessUtxo(coin.txid, coin.vout);
     let scriptDetails: ScriptDetails | undefined;
 
     if (witnessUtxo) {
@@ -107,7 +108,7 @@ export default class MarinaBroker extends Broker<keyof Marina> {
       scriptDetails = details;
     }
     return {
-      txid: coin.txID,
+      txid: coin.txid,
       vout: coin.vout,
       blindingData: coin.blindingData,
       scriptDetails: scriptDetails,
@@ -430,7 +431,7 @@ export default class MarinaBroker extends Broker<keyof Marina> {
               continue;
             }
             await this.walletRepository.updateOutpointBlindingData([
-              [{ txID: utxo.txid, vout: utxo.vout }, unblinded],
+              [{ txid: utxo.txid, vout: utxo.vout }, unblinded],
             ]);
             utxo.blindingData = unblinded;
             utxos.push(utxo);

--- a/src/domain/presenter.ts
+++ b/src/domain/presenter.ts
@@ -1,5 +1,5 @@
-import type { NetworkString, Asset } from 'marina-provider';
-import type { TxDetailsExtended, UnblindedOutput } from './transaction';
+import type { NetworkString, Asset, UnblindedOutput } from 'marina-provider';
+import type { TxDetailsExtended } from './transaction';
 import type { BlockHeader } from './chainsource';
 
 export interface LoadingValue<T> {

--- a/src/domain/pset.ts
+++ b/src/domain/pset.ts
@@ -217,12 +217,12 @@ export class PsetBuilder {
 
     // get the witness utxos from repository
     const utxosWitnessUtxos = await Promise.all(
-      unlockedUtxos.map((utxo) => this.walletRepository.getWitnessUtxo(utxo.txID, utxo.vout))
+      unlockedUtxos.map((utxo) => this.walletRepository.getWitnessUtxo(utxo.txid, utxo.vout))
     );
 
     ins.push(
       ...unlockedUtxos.map((utxo, i) => ({
-        txid: utxo.txID,
+        txid: utxo.txid,
         txIndex: utxo.vout,
         sighashType: Transaction.SIGHASH_ALL,
         witnessUtxo: utxosWitnessUtxos[i],
@@ -258,13 +258,13 @@ export class PsetBuilder {
 
       const witnessUtxos = await Promise.all(
         coinSelection.utxos.map((utxo) =>
-          this.walletRepository.getWitnessUtxo(utxo.txID, utxo.vout)
+          this.walletRepository.getWitnessUtxo(utxo.txid, utxo.vout)
         )
       );
 
       updater.addInputs(
         coinSelection.utxos.map((utxo, i) => ({
-          txid: utxo.txID,
+          txid: utxo.txid,
           txIndex: utxo.vout,
           sighashType: Transaction.SIGHASH_ALL,
           witnessUtxo: witnessUtxos[i],
@@ -392,7 +392,7 @@ export class PsetBuilder {
         [{ asset: networks[network].assetHash, amount: feeAmount }],
         // exclude the already selected utxos used in the pset inputs
         updater.pset.inputs.map((input) => ({
-          txID: Buffer.from(input.previousTxid).reverse().toString('hex'),
+          txid: Buffer.from(input.previousTxid).reverse().toString('hex'),
           vout: input.previousTxIndex,
         })),
         ...fromAccounts
@@ -400,13 +400,13 @@ export class PsetBuilder {
 
       const newWitnessUtxos = await Promise.all(
         newCoinSelection.utxos.map((utxo) => {
-          return this.walletRepository.getWitnessUtxo(utxo.txID, utxo.vout);
+          return this.walletRepository.getWitnessUtxo(utxo.txid, utxo.vout);
         })
       );
 
       newIns.push(
         ...newCoinSelection.utxos.map((utxo, i) => ({
-          txid: utxo.txID,
+          txid: utxo.txid,
           txIndex: utxo.vout,
           sighashType: Transaction.SIGHASH_ALL,
           witnessUtxo: newWitnessUtxos[i],
@@ -517,7 +517,7 @@ export class PsetBuilder {
     // we'll need this to persist the taxi blinding data in wallet repository
     const outpointsToBlindingData: [
       {
-        txID: string;
+        txid: string;
         vout: number;
       },
       UnblindingData
@@ -525,7 +525,7 @@ export class PsetBuilder {
     for (const [index, input] of pset.inputs.entries()) {
       outpointsToBlindingData.push([
         {
-          txID: Buffer.from(input.previousTxid).reverse().toString('hex'),
+          txid: Buffer.from(input.previousTxid).reverse().toString('hex'),
           vout: input.previousTxIndex,
         },
         inBlindingData[index],
@@ -585,13 +585,13 @@ export class PsetBuilder {
     // get the witness utxos from repository
     const utxosWitnessUtxos = await Promise.all(
       coinSelection.utxos.map((utxo) => {
-        return this.walletRepository.getWitnessUtxo(utxo.txID, utxo.vout);
+        return this.walletRepository.getWitnessUtxo(utxo.txid, utxo.vout);
       })
     );
 
     ins.push(
       ...coinSelection.utxos.map((utxo, i) => ({
-        txid: utxo.txID,
+        txid: utxo.txid,
         txIndex: utxo.vout,
         sighashType: Transaction.SIGHASH_ALL,
         witnessUtxo: utxosWitnessUtxos[i],

--- a/src/domain/repository.ts
+++ b/src/domain/repository.ts
@@ -7,9 +7,11 @@ import type {
   DataRecipient,
   NetworkString,
   ScriptDetails,
+  UnblindedOutput,
+  UnblindingData,
 } from 'marina-provider';
 import { AccountType } from 'marina-provider';
-import type { UnblindingData, CoinSelection, TxDetails, UnblindedOutput } from './transaction';
+import type { CoinSelection, TxDetails } from './transaction';
 import Browser from 'webextension-polyfill';
 import type { Encrypted } from './encryption';
 import { encrypt } from './encryption';
@@ -83,7 +85,7 @@ export interface AppRepository {
 
 type MaybeNull<T> = Promise<T | null>;
 
-export type Outpoint = { txID: string; vout: number };
+export type Outpoint = Pick<UnblindedOutput, 'txid' | 'vout'>;
 
 /**
  *  WalletRepository stores all the chain data (transactions, scripts, blinding data and accounts details)
@@ -108,7 +110,7 @@ export interface WalletRepository {
   updateScriptDetails(scriptToDetails: Record<string, ScriptDetails>): Promise<void>;
   updateTxDetails(txIDtoDetails: Record<string, TxDetails>): Promise<void>;
   updateOutpointBlindingData(
-    outpointToBlindingData: Array<[{ txID: string; vout: number }, UnblindingData]>
+    outpointToBlindingData: Array<[Outpoint, UnblindingData]>
   ): Promise<void>;
 
   getEncryptedMnemonic(): Promise<Encrypted | undefined>;

--- a/src/extension/components/button-transaction.tsx
+++ b/src/extension/components/button-transaction.tsx
@@ -129,7 +129,7 @@ const ButtonTransaction: React.FC<Props> = ({ txDetails, assetSelected }) => {
           </div>
           <div>
             <p className="text-base font-medium">ID transaction</p>
-            <p className="wrap text-xs font-light break-all">{txDetails.txID}</p>
+            <p className="wrap text-xs font-light break-all">{txDetails.txid}</p>
           </div>
         </div>
         <Button className="w-full" onClick={() => handleOpenExplorer()}>

--- a/src/extension/popups/sign-pset.tsx
+++ b/src/extension/popups/sign-pset.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import zkpLib from '@vulpemventures/secp256k1-zkp';
 import Button from '../components/button';
 import ShellConnectPopup from '../components/shell-connect-popup';
 import ModalUnlock from '../components/modal-unlock';
@@ -11,91 +10,18 @@ import {
 } from '../../infrastructure/storage/common';
 import { SignerService } from '../../application/signer';
 import { popupResponseMessage } from '../../domain/message';
-import { AssetHash, ElementsValue, Pset } from 'liquidjs-lib';
+import { Pset } from 'liquidjs-lib';
 import { useBackgroundPortContext } from '../context/background-port-context';
 import { useStorageContext } from '../context/storage-context';
-import type { ScriptDetails, UnblindedOutput } from 'marina-provider';
 import { useToastContext } from '../context/toast-context';
 import { extractErrorMessage } from '../utility/error';
-import type { AppRepository, AssetRepository, WalletRepository } from '../../domain/repository';
-import { WalletRepositoryUnblinder } from '../../application/unblinder';
 import { fromSatoshi } from '../utility';
 import { Spinner } from '../components/spinner';
+import type { TxDetailsExtended } from '../../domain/transaction';
+import { computeTxDetailsExtended } from '../../domain/transaction';
+import { MainAccount, MainAccountLegacy, MainAccountTest } from '../../application/account';
 
-interface PsetInfos {
-  txID: string;
-  utxosInInputs: UnblindedOutput[];
-  walletOutputs: ({ asset: string; value: number } & ScriptDetails)[];
-  feeOutputAmount: number;
-}
-
-async function getPsetInformations(
-  psetb64: string,
-  appRepository: AppRepository,
-  walletRepository: WalletRepository,
-  assetRepository: AssetRepository
-): Promise<PsetInfos> {
-  const pset = Pset.fromBase64(psetb64);
-  const network = await appRepository.getNetwork();
-  if (!network) throw new Error('unknown network');
-  const unsignedTx = pset.unsignedTx();
-
-  const result: PsetInfos = {
-    txID: unsignedTx.getId(),
-    utxosInInputs: [],
-    walletOutputs: [],
-    feeOutputAmount: 0,
-  };
-
-  const inputsBlindingData = await walletRepository.getOutputBlindingData(
-    ...pset.inputs.map((input) => ({
-      txid: Buffer.from(input.previousTxid).reverse().toString('hex'),
-      vout: input.previousTxIndex,
-    }))
-  );
-
-  result.utxosInInputs = inputsBlindingData;
-
-  const allWalletScripts = await walletRepository.getAccountScripts(network);
-  const unblinder = new WalletRepositoryUnblinder(
-    walletRepository,
-    appRepository,
-    assetRepository,
-    await zkpLib()
-  );
-
-  for (const output of unsignedTx.outs) {
-    if (!output.script || output.script.length === 0) {
-      result.feeOutputAmount = ElementsValue.fromBytes(output.value).number; // fee output is always unconfidential
-      continue;
-    }
-
-    const script = Buffer.from(output.script).toString('hex');
-    const scriptDetails = allWalletScripts[script];
-    if (scriptDetails) {
-      const value = ElementsValue.fromBytes(output.value);
-      if (value.isConfidential) {
-        const [unblinded] = await unblinder.unblind(output);
-        if (unblinded instanceof Error) continue;
-        result.walletOutputs.push({
-          ...scriptDetails,
-          asset: unblinded.asset,
-          value: unblinded.value,
-        });
-      } else {
-        result.walletOutputs.push({
-          ...scriptDetails,
-          asset: AssetHash.fromBytes(output.asset).hex,
-          value: value.number,
-        });
-      }
-    }
-  }
-
-  return result;
-}
-
-const PsetView: React.FC<PsetInfos> = ({ txID, utxosInInputs, walletOutputs, feeOutputAmount }) => {
+const PsetView: React.FC<TxDetailsExtended> = ({ txFlow }) => {
   const { cache } = useStorageContext();
   const getPrecision = (asset: string) => {
     if (!cache || !cache.assetsDetails || !cache.assetsDetails.value[asset]) return 8;
@@ -114,28 +40,40 @@ const PsetView: React.FC<PsetInfos> = ({ txID, utxosInInputs, walletOutputs, fee
     <div className="flex flex-col">
       <p className="mt-4 text-base font-medium text-center">Requests you to send</p>
       <div className="container flex flex-col">
-        {walletOutputs.map(({ asset, value, accountName }, index) => (
-          <div key={index}>
-            <div className="container flex justify-between mt-6">
-              <span className="text-lg font-medium">
-                {fromSatoshi(value, getPrecision(asset))}{' '}
-              </span>
-              <span className="text-lg font-medium">{getTicker(asset)}</span>
+        {Object.entries(txFlow)
+          .filter(([, value]) => value > 0)
+          .map(([asset, value], index, array) => (
+            <div key={index}>
+              <div className="container flex justify-between mt-6">
+                <span className="text-lg font-medium">
+                  {fromSatoshi(value, getPrecision(asset))}{' '}
+                </span>
+                <span className="text-lg font-medium">{getTicker(asset)}</span>
+              </div>
+              {index < array.length - 1 && (
+                <div className="w-48 mx-auto border-b-0.5 border-primary pt-1.5" />
+              )}
             </div>
-            <div className="container flex items-baseline justify-between">
-              <span className="mr-2 text-lg font-medium">To: </span>
-              <span className="font-small text-sm break-all">{accountName}</span>
-            </div>
-          </div>
-        ))}
+          ))}
       </div>
-      <p className="mt-2 text-base font-medium">
-        Requests you to sign {utxosInInputs.filter(({ blindingData }) => !!blindingData).length}{' '}
-        utxo(s)
-      </p>
-      <p className="mt-2 text-base font-medium">
-        Fee output: {fromSatoshi(feeOutputAmount, 8)} L-BTC
-      </p>
+      <p className="mt-4 text-base font-medium text-center">Requests you to spend</p>
+      <div className="container flex flex-col">
+        {Object.entries(txFlow)
+          .filter(([, value]) => value < 0)
+          .map(([asset, value], index, array) => (
+            <div key={index}>
+              <div className="container flex justify-between mt-6">
+                <span className="text-lg font-medium">
+                  {fromSatoshi(Math.abs(value), getPrecision(asset))}{' '}
+                </span>
+                <span className="text-lg font-medium">{getTicker(asset)}</span>
+              </div>
+              {index < array.length - 1 && (
+                <div className="w-48 mx-auto border-b-0.5 border-primary pt-1.5" />
+              )}
+            </div>
+          ))}
+      </div>
     </div>
   );
 };
@@ -146,13 +84,13 @@ export interface SignTransactionPopupResponse {
 }
 
 const ConnectSignTransaction: React.FC = () => {
-  const { walletRepository, appRepository, assetRepository } = useStorageContext();
+  const { walletRepository, appRepository } = useStorageContext();
   const { showToast } = useToastContext();
   const { backgroundPort } = useBackgroundPortContext();
 
   const [isModalUnlockOpen, showUnlockModal] = useState<boolean>(false);
   const [error, setError] = useState<string>();
-  const [psetInfos, setPsetInfos] = useState<PsetInfos>();
+  const [txDetails, setTxDetails] = useState<TxDetailsExtended>();
 
   const psetToSign = useSelectPopupPsetToSign();
   const hostname = useSelectPopupHostname();
@@ -163,9 +101,23 @@ const ConnectSignTransaction: React.FC = () => {
   useEffect(() => {
     const init = async () => {
       if (!psetToSign) return;
-      setPsetInfos(
-        await getPsetInformations(psetToSign, appRepository, walletRepository, assetRepository)
+      const network = await appRepository.getNetwork();
+      if (!network) throw new Error('unknown network');
+      const pset = Pset.fromBase64(psetToSign);
+
+      const mainAccountsScripts = await walletRepository.getAccountScripts(
+        network,
+        MainAccountLegacy,
+        network === 'liquid' ? MainAccount : MainAccountTest
       );
+
+      const txDetailsExtended = await computeTxDetailsExtended(
+        appRepository,
+        walletRepository,
+        mainAccountsScripts
+      )({ height: -1, hex: pset.unsignedTx().toHex() });
+
+      setTxDetails(txDetailsExtended);
     };
     init().catch((e) => {
       console.error(e);
@@ -214,13 +166,13 @@ const ConnectSignTransaction: React.FC = () => {
         <>
           <h1 className="mt-8 text-2xl font-medium text-center break-all">{hostname}</h1>
 
-          {!psetInfos ? (
+          {!txDetails ? (
             <div className="flex flex-col items-center mt-8">
               <Spinner />
               <p className="font-medium">Loading PSET data...</p>
             </div>
           ) : (
-            <PsetView {...psetInfos} />
+            <PsetView {...txDetails} />
           )}
 
           <ButtonsAtBottom>

--- a/src/extension/popups/sign-pset.tsx
+++ b/src/extension/popups/sign-pset.tsx
@@ -76,7 +76,6 @@ async function getPsetInformations(
       const value = ElementsValue.fromBytes(output.value);
       if (value.isConfidential) {
         const [unblinded] = await unblinder.unblind(output);
-        console.log('unblinded', unblinded);
         if (unblinded instanceof Error) continue;
         result.walletOutputs.push({
           ...scriptDetails,
@@ -131,11 +130,11 @@ const PsetView: React.FC<PsetInfos> = ({ txID, utxosInInputs, walletOutputs, fee
         ))}
       </div>
       <p className="mt-2 text-base font-medium">
-        and requests you to sign {utxosInInputs.filter(({ blindingData }) => !!blindingData).length}{' '}
+        Requests you to sign {utxosInInputs.filter(({ blindingData }) => !!blindingData).length}{' '}
         utxo(s)
       </p>
       <p className="mt-2 text-base font-medium">
-        fee output: {fromSatoshi(feeOutputAmount, 8)} L-BTC
+        Fee output: {fromSatoshi(feeOutputAmount, 8)} L-BTC
       </p>
     </div>
   );

--- a/src/extension/popups/sign-pset.tsx
+++ b/src/extension/popups/sign-pset.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import zkpLib from '@vulpemventures/secp256k1-zkp';
 import Button from '../components/button';
 import ShellConnectPopup from '../components/shell-connect-popup';
 import ModalUnlock from '../components/modal-unlock';
@@ -10,9 +11,135 @@ import {
 } from '../../infrastructure/storage/common';
 import { SignerService } from '../../application/signer';
 import { popupResponseMessage } from '../../domain/message';
-import { Pset } from 'liquidjs-lib';
+import { AssetHash, ElementsValue, Pset } from 'liquidjs-lib';
 import { useBackgroundPortContext } from '../context/background-port-context';
 import { useStorageContext } from '../context/storage-context';
+import type { ScriptDetails, UnblindedOutput } from 'marina-provider';
+import { useToastContext } from '../context/toast-context';
+import { extractErrorMessage } from '../utility/error';
+import type { AppRepository, AssetRepository, WalletRepository } from '../../domain/repository';
+import { WalletRepositoryUnblinder } from '../../application/unblinder';
+import { fromSatoshi } from '../utility';
+import { Spinner } from '../components/spinner';
+
+interface PsetInfos {
+  txID: string;
+  utxosInInputs: UnblindedOutput[];
+  walletOutputs: ({ asset: string; value: number } & ScriptDetails)[];
+  feeOutputAmount: number;
+}
+
+async function getPsetInformations(
+  psetb64: string,
+  appRepository: AppRepository,
+  walletRepository: WalletRepository,
+  assetRepository: AssetRepository
+): Promise<PsetInfos> {
+  const pset = Pset.fromBase64(psetb64);
+  const network = await appRepository.getNetwork();
+  if (!network) throw new Error('unknown network');
+  const unsignedTx = pset.unsignedTx();
+
+  const result: PsetInfos = {
+    txID: unsignedTx.getId(),
+    utxosInInputs: [],
+    walletOutputs: [],
+    feeOutputAmount: 0,
+  };
+
+  const inputsBlindingData = await walletRepository.getOutputBlindingData(
+    ...pset.inputs.map((input) => ({
+      txid: Buffer.from(input.previousTxid).reverse().toString('hex'),
+      vout: input.previousTxIndex,
+    }))
+  );
+
+  result.utxosInInputs = inputsBlindingData;
+
+  const allWalletScripts = await walletRepository.getAccountScripts(network);
+  const unblinder = new WalletRepositoryUnblinder(
+    walletRepository,
+    appRepository,
+    assetRepository,
+    await zkpLib()
+  );
+
+  for (const output of unsignedTx.outs) {
+    if (!output.script || output.script.length === 0) {
+      result.feeOutputAmount = ElementsValue.fromBytes(output.value).number; // fee output is always unconfidential
+      continue;
+    }
+
+    const script = Buffer.from(output.script).toString('hex');
+    const scriptDetails = allWalletScripts[script];
+    if (scriptDetails) {
+      const value = ElementsValue.fromBytes(output.value);
+      if (value.isConfidential) {
+        const [unblinded] = await unblinder.unblind(output);
+        console.log('unblinded', unblinded);
+        if (unblinded instanceof Error) continue;
+        result.walletOutputs.push({
+          ...scriptDetails,
+          asset: unblinded.asset,
+          value: unblinded.value,
+        });
+      } else {
+        result.walletOutputs.push({
+          ...scriptDetails,
+          asset: AssetHash.fromBytes(output.asset).hex,
+          value: value.number,
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
+const PsetView: React.FC<PsetInfos> = ({ txID, utxosInInputs, walletOutputs, feeOutputAmount }) => {
+  const { cache } = useStorageContext();
+  const getPrecision = (asset: string) => {
+    if (!cache || !cache.assetsDetails || !cache.assetsDetails.value[asset]) return 8;
+    const assetInfo = cache.assetsDetails.value[asset];
+    return assetInfo.precision;
+  };
+
+  const getTicker = (asset: string) => {
+    if (!cache || !cache.assetsDetails || !cache.assetsDetails.value[asset])
+      return asset.slice(0, 4);
+    const assetInfo = cache.assetsDetails.value[asset];
+    return assetInfo.ticker;
+  };
+
+  return (
+    <div className="flex flex-col">
+      <p className="mt-4 text-base font-medium text-center">Requests you to send</p>
+      <div className="container flex flex-col">
+        {walletOutputs.map(({ asset, value, accountName }, index) => (
+          <div key={index}>
+            <div className="container flex justify-between mt-6">
+              <span className="text-lg font-medium">
+                {fromSatoshi(value, getPrecision(asset))}{' '}
+              </span>
+              <span className="text-lg font-medium">{getTicker(asset)}</span>
+            </div>
+            <div className="container flex items-baseline justify-between">
+              <span className="mr-2 text-lg font-medium">To: </span>
+              <span className="font-small text-sm break-all">{accountName}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+      <p className="mt-2 text-base font-medium">
+        and requests you to sign {utxosInInputs.filter(({ blindingData }) => !!blindingData).length}{' '}
+        utxo(s)
+      </p>
+      <p className="mt-2 text-base font-medium">
+        fee output: {fromSatoshi(feeOutputAmount, 8)} L-BTC
+      </p>
+    </div>
+  );
+};
 
 export interface SignTransactionPopupResponse {
   accepted: boolean;
@@ -20,17 +147,33 @@ export interface SignTransactionPopupResponse {
 }
 
 const ConnectSignTransaction: React.FC = () => {
-  const { walletRepository, appRepository } = useStorageContext();
+  const { walletRepository, appRepository, assetRepository } = useStorageContext();
+  const { showToast } = useToastContext();
   const { backgroundPort } = useBackgroundPortContext();
 
   const [isModalUnlockOpen, showUnlockModal] = useState<boolean>(false);
-  const [error, setError] = useState<string>('');
+  const [error, setError] = useState<string>();
+  const [psetInfos, setPsetInfos] = useState<PsetInfos>();
 
   const psetToSign = useSelectPopupPsetToSign();
   const hostname = useSelectPopupHostname();
 
   const handleModalUnlockClose = () => showUnlockModal(false);
   const handleUnlockModalOpen = () => showUnlockModal(true);
+
+  useEffect(() => {
+    const init = async () => {
+      if (!psetToSign) return;
+      setPsetInfos(
+        await getPsetInformations(psetToSign, appRepository, walletRepository, assetRepository)
+      );
+    };
+    init().catch((e) => {
+      console.error(e);
+      setError(extractErrorMessage(e));
+      showToast(extractErrorMessage(e));
+    });
+  }, [psetToSign]);
 
   const sendResponseMessage = (accepted: boolean, signedPset?: string) => {
     return backgroundPort.sendMessage(popupResponseMessage({ accepted, signedPset }));
@@ -65,19 +208,21 @@ const ConnectSignTransaction: React.FC = () => {
 
   return (
     <ShellConnectPopup
-      className="h-popupContent container pb-20 mx-auto text-center bg-bottom bg-no-repeat"
+      className="h-popupContent max-w-sm pb-20 text-center bg-bottom bg-no-repeat"
       currentPage="Sign PSET"
     >
-      {error.length === 0 ? (
+      {!error ? (
         <>
-          <h1 className="mt-8 text-2xl font-medium break-all">{hostname}</h1>
+          <h1 className="mt-8 text-2xl font-medium text-center break-all">{hostname}</h1>
 
-          <p className="mt-4 text-base font-medium">Requests you to spend</p>
-
-          <p className="text-small mt-4 font-medium">
-            {' '}
-            <b>WARNING</b> This transaction could potentially spend all of your funds.
-          </p>
+          {!psetInfos ? (
+            <div className="flex flex-col items-center mt-8">
+              <Spinner />
+              <p className="font-medium">Loading PSET data...</p>
+            </div>
+          ) : (
+            <PsetView {...psetInfos} />
+          )}
 
           <ButtonsAtBottom>
             <Button isOutline={true} onClick={rejectSignRequest} textBase={true}>
@@ -97,6 +242,7 @@ const ConnectSignTransaction: React.FC = () => {
             className="w-36 container mx-auto mt-10"
             onClick={handleUnlockModalOpen}
             textBase={true}
+            disabled={psetToSign === undefined}
           >
             Unlock
           </Button>

--- a/src/extension/popups/sign-pset.tsx
+++ b/src/extension/popups/sign-pset.tsx
@@ -39,37 +39,37 @@ const PsetView: React.FC<TxDetailsExtended> = ({ txFlow }) => {
   return (
     <div className="flex flex-col">
       <p className="mt-4 text-base font-medium text-center">Requests you to send</p>
-      <div className="container flex flex-col">
+      <div className="container flex flex-col mt-6">
         {Object.entries(txFlow)
           .filter(([, value]) => value > 0)
           .map(([asset, value], index, array) => (
             <div key={index}>
-              <div className="container flex justify-between mt-6">
+              <div className="container flex justify-between">
                 <span className="text-lg font-medium">
                   {fromSatoshi(value, getPrecision(asset))}{' '}
                 </span>
                 <span className="text-lg font-medium">{getTicker(asset)}</span>
               </div>
               {index < array.length - 1 && (
-                <div className="w-48 mx-auto border-b-0.5 border-primary pt-1.5" />
+                <div className="w-64 mx-auto border-b-0.5 border-primary pt-1.5 mb-1.5" />
               )}
             </div>
           ))}
       </div>
       <p className="mt-4 text-base font-medium text-center">Requests you to spend</p>
-      <div className="container flex flex-col">
+      <div className="container flex flex-col mt-6">
         {Object.entries(txFlow)
           .filter(([, value]) => value < 0)
           .map(([asset, value], index, array) => (
             <div key={index}>
-              <div className="container flex justify-between mt-6">
+              <div className="container flex justify-between">
                 <span className="text-lg font-medium">
                   {fromSatoshi(Math.abs(value), getPrecision(asset))}{' '}
                 </span>
                 <span className="text-lg font-medium">{getTicker(asset)}</span>
               </div>
               {index < array.length - 1 && (
-                <div className="w-48 mx-auto border-b-0.5 border-primary pt-1.5" />
+                <div className="w-64 mx-auto border-b-0.5 border-primary pt-1.5 mb-1.5" />
               )}
             </div>
           ))}

--- a/src/extension/popups/sign-pset.tsx
+++ b/src/extension/popups/sign-pset.tsx
@@ -15,7 +15,7 @@ import { useBackgroundPortContext } from '../context/background-port-context';
 import { useStorageContext } from '../context/storage-context';
 import { useToastContext } from '../context/toast-context';
 import { extractErrorMessage } from '../utility/error';
-import { fromSatoshi } from '../utility';
+import { fromSatoshiStr } from '../utility';
 import { Spinner } from '../components/spinner';
 import type { TxDetailsExtended } from '../../domain/transaction';
 import { computeTxDetailsExtended } from '../../domain/transaction';
@@ -38,25 +38,7 @@ const PsetView: React.FC<TxDetailsExtended> = ({ txFlow }) => {
 
   return (
     <div className="flex flex-col">
-      <p className="mt-4 text-base font-medium text-center">Requests you to send</p>
-      <div className="container flex flex-col mt-6">
-        {Object.entries(txFlow)
-          .filter(([, value]) => value > 0)
-          .map(([asset, value], index, array) => (
-            <div key={index}>
-              <div className="container flex justify-between">
-                <span className="text-lg font-medium">
-                  {fromSatoshi(value, getPrecision(asset))}{' '}
-                </span>
-                <span className="text-lg font-medium">{getTicker(asset)}</span>
-              </div>
-              {index < array.length - 1 && (
-                <div className="w-64 mx-auto border-b-0.5 border-primary pt-1.5 mb-1.5" />
-              )}
-            </div>
-          ))}
-      </div>
-      <p className="mt-4 text-base font-medium text-center">Requests you to spend</p>
+      <p className="mb-4 text-base font-medium text-center">Requests you to spend</p>
       <div className="container flex flex-col mt-6">
         {Object.entries(txFlow)
           .filter(([, value]) => value < 0)
@@ -64,7 +46,7 @@ const PsetView: React.FC<TxDetailsExtended> = ({ txFlow }) => {
             <div key={index}>
               <div className="container flex justify-between">
                 <span className="text-lg font-medium">
-                  {fromSatoshi(Math.abs(value), getPrecision(asset))}{' '}
+                  {fromSatoshiStr(Math.abs(value), getPrecision(asset))}{' '}
                 </span>
                 <span className="text-lg font-medium">{getTicker(asset)}</span>
               </div>

--- a/src/infrastructure/storage/wallet-repository.ts
+++ b/src/infrastructure/storage/wallet-repository.ts
@@ -1,14 +1,16 @@
 // @ts-ignore
 import coinselect from 'coinselect';
 // import coinselectSplit from 'coinselect/split';
-import type { NetworkString, ScriptDetails, UnblindingData, UnblindedOutput } from 'marina-provider';
+import type {
+  NetworkString,
+  ScriptDetails,
+  UnblindingData,
+  UnblindedOutput,
+} from 'marina-provider';
 import Browser from 'webextension-polyfill';
 import type { TxOutput } from 'liquidjs-lib';
 import { Transaction } from 'liquidjs-lib';
-import type {
-  TxDetails,
-  CoinSelection,
-} from '../../domain/transaction';
+import type { TxDetails, CoinSelection } from '../../domain/transaction';
 import { computeBalances } from '../../domain/transaction';
 import type { AccountDetails, WalletRepository, Outpoint } from '../../domain/repository';
 import { DynamicStorageKey } from './dynamic-key';
@@ -485,10 +487,11 @@ export class WalletStorageAPI implements WalletRepository {
       Object.entries(wholeStorage)
         .filter(
           ([key, value]) =>
-            ScriptDetailsKey.is(key) &&
-            (value as ScriptDetails).networks.includes(network)
+            ScriptDetailsKey.is(key) && (value as ScriptDetails).networks.includes(network)
         )
-        .filter(([_, value]) => (names && names.length > 0) ? names.includes((value as ScriptDetails).accountName) : true)
+        .filter(([_, value]) =>
+          names && names.length > 0 ? names.includes((value as ScriptDetails).accountName) : true
+        )
         .map(([key, value]) => [ScriptDetailsKey.decode(key)[0], value as ScriptDetails])
     );
   }

--- a/test/application.spec.ts
+++ b/test/application.spec.ts
@@ -183,14 +183,14 @@ describe('Application Layer', () => {
         // generate and faucet addresses
         let account = await factory.make('regtest', randomAccountName);
         const address = await account.getNextAddress(false);
-        const txID0 = await faucet(address.confidentialAddress, 1);
-        const txID1 = await faucet(address.confidentialAddress, 1);
+        const txid0 = await faucet(address.confidentialAddress, 1);
+        const txid1 = await faucet(address.confidentialAddress, 1);
         const addressBis = await account.getNextAddress(false);
-        const txID2 = await faucet(addressBis.confidentialAddress, 1);
-        const txID3 = await faucet(addressBis.confidentialAddress, 1);
+        const txid2 = await faucet(addressBis.confidentialAddress, 1);
+        const txid3 = await faucet(addressBis.confidentialAddress, 1);
         const changeAddress = await account.getNextAddress(true);
-        const txID4 = await faucet(changeAddress.confidentialAddress, 1);
-        const txID5 = await faucet(changeAddress.confidentialAddress, 1);
+        const txid4 = await faucet(changeAddress.confidentialAddress, 1);
+        const txid5 = await faucet(changeAddress.confidentialAddress, 1);
         await sleep(5000); // wait for the txs to be confirmed
 
         // then let's simulate re-onboarding by erasing the indexes (we "forget" the generated addresses)
@@ -219,12 +219,12 @@ describe('Application Layer', () => {
 
         // check is the txs are here
         const txs = await walletRepository.getTransactions('regtest');
-        expect(txs).toContain(txID0);
-        expect(txs).toContain(txID1);
-        expect(txs).toContain(txID2);
-        expect(txs).toContain(txID3);
-        expect(txs).toContain(txID4);
-        expect(txs).toContain(txID5);
+        expect(txs).toContain(txid0);
+        expect(txs).toContain(txid1);
+        expect(txs).toContain(txid2);
+        expect(txs).toContain(txid3);
+        expect(txs).toContain(txid4);
+        expect(txs).toContain(txid5);
         // check the utxos
         const utxos = await walletRepository.getUtxos('regtest', randomAccountName);
         expect(utxos).toHaveLength(6);
@@ -339,10 +339,10 @@ describe('Application Layer', () => {
       const transaction = Transaction.fromHex(hex);
       expect(transaction.ins).toHaveLength(2);
       const chainSource = await appRepository.getChainSource('regtest');
-      const txID = await chainSource?.broadcastTransaction(hex);
+      const txid = await chainSource?.broadcastTransaction(hex);
       await lockTransactionInputs(walletRepository, hex);
       await chainSource?.close();
-      expect(txID).toEqual(transaction.getId());
+      expect(txid).toEqual(transaction.getId());
     }, 10_000);
 
     describe('Ionio contract account', () => {
@@ -359,11 +359,11 @@ describe('Application Layer', () => {
 
         const utxo = (await walletRepository.getUtxos('regtest', ionioAccountName))[0];
         expect(utxo.blindingData).toBeTruthy();
-        const witnessUtxo = await walletRepository.getWitnessUtxo(utxo.txID, utxo.vout);
+        const witnessUtxo = await walletRepository.getWitnessUtxo(utxo.txid, utxo.vout);
         expect(witnessUtxo).toBeTruthy();
 
         const tx = contract
-          .from(utxo.txID, utxo.vout, witnessUtxo!, {
+          .from(utxo.txid, utxo.vout, witnessUtxo!, {
             asset: AssetHash.fromHex(utxo.blindingData!.asset).bytesWithoutPrefix,
             value: utxo.blindingData!.value.toString(10),
             assetBlindingFactor: Buffer.from(utxo.blindingData!.assetBlindingFactor, 'hex'),
@@ -388,10 +388,10 @@ describe('Application Layer', () => {
         const transaction = Extractor.extract(signed.pset);
         const hex = transaction.toHex();
         const chainSource = await appRepository.getChainSource('regtest');
-        const txID = await chainSource?.broadcastTransaction(hex);
+        const txid = await chainSource?.broadcastTransaction(hex);
         await lockTransactionInputs(walletRepository, hex);
         await chainSource?.close();
-        expect(txID).toEqual(transaction.getId());
+        expect(txid).toEqual(transaction.getId());
       }, 12_000);
 
       it('should be able to restore using a restorationJSON', async () => {


### PR DESCRIPTION
This PR adds `PsetView` component to `sign-pset.tsx` popup.

Here is an example of a tx spending 2 utxos and sending some L-BTC to my mainAccountTest:
![image](https://user-images.githubusercontent.com/41042567/231506038-7664f212-e906-425d-86db-01eb82b82ee5.png)

Some changes on others files are related to a duplicate type `UnblindedData`. I've drop the duplicated types and use them from marina-provider. It's only about renaming "txID" to "txid" as defined in `marina-provider`.

it closes #421 

@bordalix @tiero please review