### PR TITLE
use Promise.all in getNextAddress

### DIFF
--- a/src/application/account.ts
+++ b/src/application/account.ts
@@ -215,7 +215,7 @@ export class Account {
     if (!confidentialAddress) throw new Error('unable to create address from script:' + script);
 
     // increment the account details last used index & persist the new script details
-    await Promise.allSettled([
+    await Promise.all([
       this.walletRepository.updateAccountKeyIndex(this.name, this.network.name as NetworkString, {
         [isInternal ? 'internal' : 'external']: next + 1,
       }),


### PR DESCRIPTION
If something went wrong during the write operations on repository, no error are thrown due to `Promise.allSettled`. `Promise.all` ensures that an error will be sent in case of marina fails to persist the script.

