### PR TITLE
reverse blinding factors while encoded as hex string

### DIFF
--- a/src/application/blinder.ts
+++ b/src/application/blinder.ts
@@ -2,6 +2,7 @@ import type { OwnedInput } from 'liquidjs-lib';
 import { Pset, AssetHash, Blinder, ZKPGenerator, ZKPValidator } from 'liquidjs-lib';
 import type { WalletRepository } from '../domain/repository';
 import type { Confidential } from 'liquidjs-lib/src/confidential';
+import { h2bReversed } from './utils';
 
 export class BlinderService {
   private zkpValidator: ZKPValidator;
@@ -23,8 +24,8 @@ export class BlinderService {
       if (!unblindOutput || !unblindOutput.blindingData) continue;
       ownedInputs.push({
         asset: AssetHash.fromHex(unblindOutput.blindingData.asset).bytesWithoutPrefix,
-        assetBlindingFactor: Buffer.from(unblindOutput.blindingData.assetBlindingFactor, 'hex'),
-        valueBlindingFactor: Buffer.from(unblindOutput.blindingData.valueBlindingFactor, 'hex'),
+        assetBlindingFactor: h2bReversed(unblindOutput.blindingData.assetBlindingFactor),
+        valueBlindingFactor: h2bReversed(unblindOutput.blindingData.valueBlindingFactor),
         value: unblindOutput.blindingData.value.toString(),
         index: inputIndex,
       });

--- a/src/application/unblinder.ts
+++ b/src/application/unblinder.ts
@@ -11,6 +11,7 @@ import type {
 } from '../domain/repository';
 import { DefaultAssetRegistry } from '../port/asset-registry';
 import type { UnblindingData } from 'marina-provider';
+import { b2hReversed } from './utils';
 
 const slip77 = SLIP77Factory(ecc);
 
@@ -61,8 +62,8 @@ export class WalletRepositoryUnblinder implements Unblinder {
         unblindingResults.push({
           value: parseInt(unblinded.value, 10),
           asset: AssetHash.fromBytes(unblinded.asset).hex,
-          assetBlindingFactor: unblinded.assetBlindingFactor.toString('hex'),
-          valueBlindingFactor: unblinded.valueBlindingFactor.toString('hex'),
+          assetBlindingFactor: b2hReversed(unblinded.assetBlindingFactor),
+          valueBlindingFactor: b2hReversed(unblinded.valueBlindingFactor),
         });
       } catch (e: unknown) {
         if (e instanceof Error) {

--- a/src/application/utils.ts
+++ b/src/application/utils.ts
@@ -1,3 +1,11 @@
 export function h2b(hex: string): Buffer {
   return Buffer.from(hex, 'hex');
 }
+
+export function b2hReversed(buffer: Buffer): string {
+  return Buffer.from(buffer).reverse().toString('hex');
+}
+
+export function h2bReversed(hex: string): Buffer {
+  return h2b(hex).reverse();
+}

--- a/src/domain/pset.ts
+++ b/src/domain/pset.ts
@@ -151,8 +151,8 @@ function castTopupData(raw: RawTopupWithAssetData): TopupWithAssetReply {
     inBlindingData: raw.inBlindingData.map((data) => ({
       asset: data.asset,
       value: parseInt(data.value, 10),
-      assetBlindingFactor: Buffer.from(data.assetBlinder, 'base64').reverse().toString('hex'),
-      valueBlindingFactor: Buffer.from(data.valueBlinder, 'base64').reverse().toString('hex'),
+      assetBlindingFactor: Buffer.from(data.assetBlinder, 'base64').toString('hex'),
+      valueBlindingFactor: Buffer.from(data.valueBlinder, 'base64').toString('hex'),
     })),
     topup: {
       topupId: raw.topup.topupId,

--- a/src/domain/transaction.ts
+++ b/src/domain/transaction.ts
@@ -42,8 +42,6 @@ export function computeBalances(utxos: UnblindedOutput[]): Record<string, number
   return balances;
 }
 
-const reverseHex = (hex: string) => Buffer.from(hex, 'hex').reverse().toString('hex');
-
 export async function makeURLwithBlinders(
   transaction: Transaction,
   appRepository: AppRepository,
@@ -63,9 +61,7 @@ export async function makeURLwithBlinders(
     if (!data || !data.blindingData) continue;
 
     blinders.push(
-      `${data.blindingData.value},${data.blindingData.asset},${reverseHex(
-        data.blindingData.valueBlindingFactor
-      )},${reverseHex(data.blindingData.assetBlindingFactor)}`
+      `${data.blindingData.value},${data.blindingData.asset},${data.blindingData.valueBlindingFactor},${data.blindingData.assetBlindingFactor}`
     );
   }
 

--- a/test/application.spec.ts
+++ b/test/application.spec.ts
@@ -36,6 +36,7 @@ import {
 import { TaxiStorageAPI } from '../src/infrastructure/storage/taxi-repository';
 import { initWalletRepository } from '../src/domain/repository';
 import { computeBalances, lockTransactionInputs } from '../src/domain/transaction';
+import { h2bReversed } from '../src/application/utils';
 
 // we need this to mock the browser.storage.local calls in repositories
 // replace webextension-polyfill with a mock defined in __mocks__ folder
@@ -365,8 +366,8 @@ describe('Application Layer', () => {
           .from(utxo.txid, utxo.vout, witnessUtxo!, {
             asset: AssetHash.fromHex(utxo.blindingData!.asset).bytesWithoutPrefix,
             value: utxo.blindingData!.value.toString(10),
-            assetBlindingFactor: Buffer.from(utxo.blindingData!.assetBlindingFactor, 'hex'),
-            valueBlindingFactor: Buffer.from(utxo.blindingData!.valueBlindingFactor, 'hex'),
+            assetBlindingFactor: h2bReversed(utxo.blindingData!.assetBlindingFactor),
+            valueBlindingFactor: h2bReversed(utxo.blindingData!.valueBlindingFactor),
           })
           .functions.transferWithSum(8, 2, {
             signTransaction: async (psetb64: string) => {


### PR DESCRIPTION
This PR ensures that blinders are encoded as **reversed string**. It may be a critical breaking change for web apps using liquidjs-lib `Blinder` (should be released with a proper version management in marina-provider).

@tiero @bordalix please review