### PR TITLE
Fix and test transaction displaying

### DIFF
--- a/playwright-tests/injected-script.spec.ts
+++ b/playwright-tests/injected-script.spec.ts
@@ -5,7 +5,7 @@ import {
   makeOnboardingRestore,
   PlaywrightMarinaProvider,
   marinaURL,
-  PASSWORD,
+  switchToRegtestNetwork,
 } from './utils';
 import { faucet } from '../test/_regtest';
 
@@ -37,16 +37,7 @@ pwTest(
   'marina.signTransaction popup should display the correct amount of spent asset',
   async ({ page, extensionId, context }) => {
     await makeOnboardingRestore(page, extensionId);
-    // login and switch to regtest network
-    await page.goto(marinaURL(extensionId, 'popup.html'));
-    await page.getByPlaceholder('Enter your password').fill(PASSWORD);
-    await page.getByRole('button', { name: 'Log in' }).click();
-    await page.waitForSelector('text=Assets');
-    await page.getByAltText('menu icon').click(); // hamburger menu
-    await page.getByText('Settings').click();
-    await page.getByRole('button', { name: 'Networks' }).click();
-    await page.getByRole('button', { name: 'Liquid' }).click(); // by default on Liquid, so the button contains the network name
-    await page.getByText('Regtest').click();
+    await switchToRegtestNetwork(page, extensionId); 
 
     await page.goto(vulpemFaucetURL);
     let provider = new PlaywrightMarinaProvider(page);
@@ -97,7 +88,10 @@ pwTest(
 
     const handleSignTransactionPopup = async () => {
       const popup = await context.waitForEvent('page');
-      await popup.waitForSelector(`text=1 L-BTC`);
+      await popup.waitForSelector(`text= L-BTC`); // wait for loading to finish
+      const value = popup.getByTestId(networks.regtest.assetHash)
+      pwExpect(value).toBeTruthy();
+      pwExpect(await value.innerText()).toEqual('0.999985');
       await popup.getByRole('button', { name: 'Reject' }).click();
     };
 

--- a/playwright-tests/utils.ts
+++ b/playwright-tests/utils.ts
@@ -56,6 +56,21 @@ export const PASSWORD = 'passwordsupersecretonlyfortesting';
 export const marinaURL = (extensionID: string, path: string) =>
   `chrome-extension://${extensionID}/${path}`;
 
+export const switchToRegtestNetwork = async (page: Page, extensionID: string) => {
+// go to networks page and switch to regtest
+    await page.goto(marinaURL(extensionID, 'popup.html'));
+    await page.getByPlaceholder('Enter your password').fill(PASSWORD);
+    await page.getByRole('button', { name: 'Log in' }).click();
+    await page.waitForSelector('text=Assets');
+    await page.getByAltText('menu icon').click(); // hamburger menu
+    await page.getByText('Settings').click();
+    await page.getByRole('button', { name: 'Networks' }).click();
+    await page.getByRole('button', { name: 'Liquid' }).click(); // by default on Liquid, so the button contains the network name
+    await page.getByText('Regtest').click();
+    // wait some time for the network to switch
+    await page.waitForTimeout(2000);
+}
+
 export const makeOnboardingRestore = async (page: Page, extensionID: string) => {
   await page.goto(marinaURL(extensionID, 'home.html#initialize/welcome'));
   await page.getByRole('button', { name: 'Get Started' }).click();

--- a/src/application/presenter.ts
+++ b/src/application/presenter.ts
@@ -154,7 +154,7 @@ export class PresenterImpl implements Presenter {
           this.walletRepository,
           scripts
         )(details);
-        
+
         this.state = {
           ...this.state,
           transactions: setValue(

--- a/src/application/presenter.ts
+++ b/src/application/presenter.ts
@@ -138,18 +138,23 @@ export class PresenterImpl implements Presenter {
     );
 
     closeFns.push(
-      this.walletRepository.onNewTransaction(async (_, details: TxDetails) => {
+      this.walletRepository.onNewTransaction(async (txID: string, details: TxDetails) => {
         if (!this.state.authenticated.value) return;
         const scripts = await this.walletRepository.getAccountScripts(
           this.state.network,
           MainAccountLegacy,
           this.state.network === 'liquid' ? MainAccount : MainAccountTest
         );
+
+        const found = this.state.transactions.value.findIndex((tx) => tx.txid === txID);
+        if (found > -1) return; // skip if tx already present
+
         const extendedTxDetails = await computeTxDetailsExtended(
           this.appRepository,
           this.walletRepository,
           scripts
         )(details);
+        
         this.state = {
           ...this.state,
           transactions: setValue(
@@ -159,6 +164,8 @@ export class PresenterImpl implements Presenter {
             new Set([...this.state.walletAssets.value, ...Object.keys(extendedTxDetails.txFlow)])
           ),
         };
+
+        emits(this.state);
       })
     );
 

--- a/src/domain/transaction.ts
+++ b/src/domain/transaction.ts
@@ -173,7 +173,8 @@ export function computeTxDetailsExtended(
     const lbtcFlow = txFlow[networks[network].assetHash];
     if (!lbtcFlow) return txExtended;
 
-    if (lbtcFlow + feeAmount === 0) { // if the flow is exactly the fee amount, consider we are paying the fees
+    if (lbtcFlow + feeAmount === 0) {
+      // if the flow is exactly the fee amount, consider we are paying the fees
       txExtended.txFlow[networks[network].assetHash] = 0;
       return txExtended;
     }
@@ -183,7 +184,7 @@ export function computeTxDetailsExtended(
       txExtended.txFlow[networks[network].assetHash] = lbtcFlow + feeAmount;
       return txExtended;
     }
-  
+
     return txExtended;
   };
 }

--- a/src/domain/transaction.ts
+++ b/src/domain/transaction.ts
@@ -131,14 +131,18 @@ export function computeTxDetailsExtended(
       txFlow[asset] = (txFlow[asset] || 0) + elementsValue.number;
     }
 
+    let walletOwnsAllInputs = true;
+
     for (let inIndex = 0; inIndex < transaction.ins.length; inIndex++) {
       const input = transaction.ins[inIndex];
       const inputTxID = Buffer.from(input.hash).reverse().toString('hex');
       const inputPrevoutIndex = input.index;
 
       const output = await walletRepository.getWitnessUtxo(inputTxID, inputPrevoutIndex);
-      if (!output) continue;
-      if (!scriptsState[output.script.toString('hex')]) continue;
+      if (!output || !scriptsState[output.script.toString('hex')]) {
+        walletOwnsAllInputs = false;
+        continue;
+      }
       const elementsValue = ElementsValue.fromBytes(output.value);
 
       if (elementsValue.isConfidential) {
@@ -158,21 +162,28 @@ export function computeTxDetailsExtended(
     const network = await appRepository.getNetwork();
     if (!network) throw new Error('network not found');
 
-    // if the flow for L-BTC is -feeAmount, remove it
-    if (txFlow[networks[network].assetHash] + feeAmount === 0) {
-      if (Object.keys(txFlow).length === 1) {
-        // this prevent to remove the flow if there is only the L-BTC one (self transfer L-BTC case)
-        txFlow[networks[network].assetHash] = 0;
-      } else {
-        delete txFlow[networks[network].assetHash];
-      }
-    }
-
-    return {
+    const txExtended: TxDetailsExtended = {
       ...details,
       txid,
       txFlow,
       feeAmount,
     };
+
+    // check if we are paying the fees or not
+    const lbtcFlow = txFlow[networks[network].assetHash];
+    if (!lbtcFlow) return txExtended;
+
+    if (lbtcFlow + feeAmount === 0) { // if the flow is exactly the fee amount, consider we are paying the fees
+      txExtended.txFlow[networks[network].assetHash] = 0;
+      return txExtended;
+    }
+
+    if (walletOwnsAllInputs) {
+      // if we own all the inputs, it means we pay the fees
+      txExtended.txFlow[networks[network].assetHash] = lbtcFlow + feeAmount;
+      return txExtended;
+    }
+  
+    return txExtended;
   };
 }

--- a/src/extension/popups/sign-pset.tsx
+++ b/src/extension/popups/sign-pset.tsx
@@ -71,7 +71,7 @@ const PsetView: React.FC<TxDetailsExtended> = ({ txFlow }) => {
           .map(([asset, value], index, array) => (
             <div key={index}>
               <div className="container flex justify-between">
-                <span className="text-lg font-medium">
+                <span data-testid={asset} className="text-lg font-medium">
                   {fromSatoshiStr(Math.abs(value), getPrecision(asset))}{' '}
                 </span>
                 <span className="text-lg font-medium">{getTicker(asset)}</span>
@@ -146,6 +146,7 @@ const ConnectSignTransaction: React.FC = () => {
         mainAccountsScripts
       )({ height: -1, hex: unsignedTx.toHex() });
 
+      console.log('txDetailsExtended', txDetailsExtended.txFlow);
       setTxDetails(txDetailsExtended);
     };
     init().catch((e) => {

--- a/src/extension/wallet/transactions/index.tsx
+++ b/src/extension/wallet/transactions/index.tsx
@@ -62,14 +62,16 @@ const Transactions: React.FC = () => {
   const handleBackBtn = () => history.push(DEFAULT_ROUTE);
 
   const getFilteredTransactions = () => {
-    const seen = new Set();  
+    const seen = new Set();
 
-    return cache?.transactions.value.filter((tx) => {
-      if (tx.txFlow[assetHash] === undefined) return false
-      const duplicate = seen.has(tx.txid);
-      seen.add(tx.txid);
-      return !duplicate;
-    }) ?? [];
+    return (
+      cache?.transactions.value.filter((tx) => {
+        if (tx.txFlow[assetHash] === undefined) return false;
+        const duplicate = seen.has(tx.txid);
+        seen.add(tx.txid);
+        return !duplicate;
+      }) ?? []
+    );
   };
 
   return (
@@ -95,10 +97,9 @@ const Transactions: React.FC = () => {
           <div className="h-60 rounded-xl mb-1">
             {asset && (
               <ButtonList title="Transactions" emptyText="Your transactions will appear here">
-                {getFilteredTransactions()
-                  .map((tx, index) => {
-                    return <ButtonTransaction txDetails={tx} assetSelected={asset} key={index} />;
-                  })}
+                {getFilteredTransactions().map((tx, index) => {
+                  return <ButtonTransaction txDetails={tx} assetSelected={asset} key={index} />;
+                })}
               </ButtonList>
             )}
           </div>

--- a/src/extension/wallet/transactions/index.tsx
+++ b/src/extension/wallet/transactions/index.tsx
@@ -61,6 +61,17 @@ const Transactions: React.FC = () => {
 
   const handleBackBtn = () => history.push(DEFAULT_ROUTE);
 
+  const getFilteredTransactions = () => {
+    const seen = new Set();  
+
+    return cache?.transactions.value.filter((tx) => {
+      if (tx.txFlow[assetHash] === undefined) return false
+      const duplicate = seen.has(tx.txid);
+      seen.add(tx.txid);
+      return !duplicate;
+    }) ?? [];
+  };
+
   return (
     <ShellPopUp
       backBtnCb={handleBackBtn}
@@ -84,8 +95,7 @@ const Transactions: React.FC = () => {
           <div className="h-60 rounded-xl mb-1">
             {asset && (
               <ButtonList title="Transactions" emptyText="Your transactions will appear here">
-                {cache?.transactions.value
-                  .filter((tx) => tx.txFlow[asset.assetHash] !== undefined)
+                {getFilteredTransactions()
                   .map((tx, index) => {
                     return <ButtonTransaction txDetails={tx} assetSelected={asset} key={index} />;
                   })}


### PR DESCRIPTION
This PR removes the fee amount from L-BTC inbound/outbound transaction values. In other words, if I send 1 L-BTC + fees, the transactions will be labelled as - 1 L-BTC (fee amount still visible in tx details page).

it closes #483 

@tiero @Janaka-Steph please review