### PR TITLE
`marina.sendTransaction`:  fix amount formatting 

### DIFF
--- a/playwright-tests/utils.ts
+++ b/playwright-tests/utils.ts
@@ -174,12 +174,17 @@ export class PlaywrightMarinaProvider implements MarinaProvider {
   getAddresses(accountIDs?: string[] | undefined): Promise<Address[]> {
     throw new Error('Method not implemented.');
   }
+
   sendTransaction(
     recipients: Recipient[],
-    feeAsset?: string | undefined
+    feeAsset?: string
   ): Promise<SentTransaction> {
-    throw new Error('Method not implemented.');
+    return this.page.evaluate<SentTransaction, [string, Recipient[], string | undefined]>(
+      ([name, recipients, feeAsset]) => (window[name as any] as unknown as MarinaProvider).sendTransaction(recipients, feeAsset),
+      [Marina.PROVIDER_NAME, recipients, feeAsset]
+    );
   }
+  
   signTransaction(pset: string): Promise<string> {
     return this.page.evaluate<string, [string, string]>(
       ([name, pset]) => (window[name as any] as unknown as MarinaProvider).signTransaction(pset),

--- a/src/content/marina/marinaBroker.ts
+++ b/src/content/marina/marinaBroker.ts
@@ -315,9 +315,9 @@ export default class MarinaBroker extends Broker<keyof Marina> {
           const { accepted, signedPset } =
             await this.openAndWaitPopup<SignTransactionPopupResponse>('sign-pset');
 
+          await this.popupsRepository.clear();
           if (!accepted) throw new Error('User rejected the sign request');
           if (!signedPset) throw new Error('Something went wrong with tx signing');
-          await this.popupsRepository.clear();
 
           return successMsg(signedPset);
         }
@@ -374,7 +374,9 @@ export default class MarinaBroker extends Broker<keyof Marina> {
             'spend'
           );
 
-          if (!accepted) throw new Error('the user rejected the create tx request');
+          await this.popupsRepository.clear();
+
+          if (!accepted) throw new Error('user rejected the sendTransaction request');
           if (!signedTxHex) throw new Error('something went wrong with the tx crafting');
 
           // try to broadcast the tx

--- a/src/extension/popups/spend.tsx
+++ b/src/extension/popups/spend.tsx
@@ -110,8 +110,8 @@ const ConnectSpend: React.FC = () => {
             {spendParameters.addressRecipients.map((recipient, index) => (
               <div key={index}>
                 <div className="container flex justify-between mt-6">
-                  <span className="text-lg font-medium">
-                    {(fromSatoshi(recipient.value), getPrecision(recipient.asset))}
+                  <span data-testid={recipient.asset} className="text-lg font-medium">
+                    {fromSatoshi(recipient.value, getPrecision(recipient.asset))}
                   </span>
                   <span className="text-lg font-medium">{getTicker(recipient.asset)}</span>
                 </div>


### PR DESCRIPTION
This PR is an hotfix of the `spend.tsx` component: a typo error in `fromSatoshi` call was showing only the asset precision. It also adds a playwright test for  `marina.sendTransaction` popup.

it closes #490 

please @tiero review this

[marina-0.5.2-fix-sendTransaction.zip](https://github.com/vulpemventures/marina/files/12356252/marina-0.5.2.zip)
