### PR TITLE
Remembers invoice

### DIFF
--- a/src/domain/repository.ts
+++ b/src/domain/repository.ts
@@ -289,12 +289,12 @@ export interface RefundableSwapParams {
   derivationPath?: string;
   expectedAmount?: number;
   expirationDate?: number;
-  fundingAddress: string;
+  fundingAddress?: string;
   id?: string;
   invoice?: string;
   network: NetworkString;
   redeemScript: string;
-  refundPublicKey: string;
+  refundPublicKey?: string;
   timeoutBlockHeight?: number;
   timestamp?: number;
   txid?: string;

--- a/src/domain/repository.ts
+++ b/src/domain/repository.ts
@@ -287,11 +287,14 @@ export interface RefundableSwapParams {
   blindingKey: string;
   confidentialAddress?: string;
   derivationPath?: string;
-  fundingAddress?: string;
+  expectedAmount?: number;
+  expirationDate?: number;
+  fundingAddress: string;
   id?: string;
-  network?: NetworkString;
+  invoice?: string;
+  network: NetworkString;
   redeemScript: string;
-  refundPublicKey?: string;
+  refundPublicKey: string;
   timeoutBlockHeight?: number;
   timestamp?: number;
   txid?: string;
@@ -300,6 +303,7 @@ export interface RefundableSwapParams {
 export interface RefundableSwapsRepository {
   addSwap(swap: RefundableSwapParams): Promise<void>;
   findSwapWithAddress(address: string): Promise<RefundableSwapParams | undefined>;
+  findSwapWithInvoice(invoice: string): Promise<RefundableSwapParams | undefined>;
   findSwapWithTxid(txid: string): Promise<RefundableSwapParams | undefined>;
   getSwaps(): Promise<RefundableSwapParams[]>;
   updateSwap(swap: RefundableSwapParams): Promise<void>;

--- a/src/extension/components/button-transaction.tsx
+++ b/src/extension/components/button-transaction.tsx
@@ -88,7 +88,7 @@ const ButtonTransaction: React.FC<Props> = ({ assetSelected, swap, txDetails }: 
                 : '??'}{' '}
               {assetSelected.ticker}
             </span>
-            {swap && confirmed && (
+            {swap && Boolean(confirmed) && (
               <span className="bg-smokeLight text-xxs px-1 py-0 font-semibold text-white rounded-full">
                 Refundable
               </span>
@@ -150,7 +150,7 @@ const ButtonTransaction: React.FC<Props> = ({ assetSelected, swap, txDetails }: 
             <p className="wrap text-xs font-light break-all">{txDetails.txid}</p>
           </div>
         </div>
-        {swap ? (
+        {swap && confirmed ? (
           <div className="flex justify-between">
             <Button
               isOutline={true}

--- a/src/infrastructure/storage/refundable-swaps-repository.ts
+++ b/src/infrastructure/storage/refundable-swaps-repository.ts
@@ -40,6 +40,10 @@ export class RefundableSwapsStorageAPI implements RefundableSwapsRepository {
     );
   }
 
+  async findSwapWithInvoice(invoice: string): Promise<RefundableSwapParams | undefined> {
+    return (await this.getSwapData()).find((s) => s.invoice === invoice);
+  }
+
   async findSwapWithTxid(txid: string): Promise<RefundableSwapParams | undefined> {
     return (await this.getSwapData()).find((s) => s.txid === txid);
   }


### PR DESCRIPTION
This PR makes Marina remember previous invoices and don't ask for a submarine swap again.

Implements a new updater strategy for refundable tx (tx from failed swaps):
- these swaps can be in 2 different scenarios:
  - they were broadcasted (ie, have a txid)
    - remove them if they were swepts by Boltz (not refundable anymore because were spent)
  - user didn't went through and didn't broadcasted the tx
    - kept in cache cause we can't ask Boltz for another swap with the same invoice, so we will use this values if that happens
    - after invoice expiration date these swaps are removed from storage 

Fixes bugs on tx list:
  - Wrong 0 
  - Refund button was available on tx not confirmed

@tiero please review